### PR TITLE
Pep0008

### DIFF
--- a/db/mongodb.py
+++ b/db/mongodb.py
@@ -4,489 +4,547 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from pymongo import MongoClient
-from pymongo import ASCENDING
-from pymongo import DESCENDING
-from bson.dbref import DBRef
-import gridfs
-import sys
+from copy import deepcopy
+import datetime
 from hashlib import md5
 import logging
 import re
-import translitcodec
-import pytz
-import datetime
-from bson.objectid import ObjectId
-from copy import deepcopy
 from uuid import uuid4
 import types
 
+from bson.dbref import DBRef
+from bson.objectid import ObjectId
+import gridfs
+import pytz
+import translitcodec
+
+from pymongo import MongoClient
+
 
 class MongoDatabase(object):
-  """
-  Database handler for a MongoDB backend
-  """
+    """
+    Database handler for a MongoDB backend
+    """
 
-  def __init__(self, base_config):
-    client = MongoClient(base_config.DB_HOST, base_config.DB_PORT)
-    self.db = client[base_config.DB_NAME]
-    self.base_config = base_config
-    self.fs = gridfs.GridFS(self.db)
-    self.slugify_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
+    def __init__(self, base_config):
+        client = MongoClient(base_config.DB_HOST, base_config.DB_PORT)
+        self.db = client[base_config.DB_NAME]
+        self.base_config = base_config
+        self.fs = gridfs.GridFS(self.db)
+        self.slugify_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
 
-  def setup(self, config):
-    """
-    Initialize database, if not yet done. Shouln't destroy anything.
-    """
-    # body
-    self.config = config
-    self.body_uid = config['city']['_id']
-    
-    """
-    self.db.committee.ensure_index([('originalId', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # meeting
-    self.db.meeting.ensure_index([('originalId', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # agendaitem
-    self.db.agendaitem.ensure_index([('originalId', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # paper
-    self.db.paper.ensure_index([('originalId', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # document = attachment
-    self.db.document.ensure_index([('identifier', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # organization
-    self.db.organization.ensure_index([('identifier', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # person
-    self.db.person.ensure_index([('originalId', ASCENDING), ('body', ASCENDING)], unique=True)
-    
-    # location 
-    #self.db.document.ensure_index([('originalId', ASCENDING), ('rs', ASCENDING)], unique=True)
-    
-    #self.db.attachments.ensure_index([('originalId', ASCENDING), ('rs', ASCENDING)], unique=True)
-    """
-  def erase(self):
-    """
-    Delete all data from database.
-    """
-    self.db.queue.remove({})
-    self.db.agendaItem.remove({})
-    self.db.consultation.remove({})
-    self.db.file.remove({})
-    self.db.legislativeTerm.remove({})
-    self.db.location.remove({})
-    self.db.meeting.remove({})
-    self.db.membership.remove({})
-    self.db.organization.remove({})
-    self.db.paper.remove({})
-    self.db.person.remove({})
-    self.db.fs.files.remove({})
-    self.db.fs.chunks.remove({})
+    def setup(self, config):
+        """
+        Initialize database, if not yet done. Shouln't destroy anything.
+        """
+        # body
+        self.config = config
+        self.body_uid = config['city']['_id']
 
-  def get_config(self, body_uid):
-    """
-    Returns Config JSON
-    """
-    config = self.db.config.find_one()
-    if '_id' in config:
-      del config['_id']
-    local_config = self.db.body.find_one({'_id': ObjectId(body_uid)})
-    if 'config' in local_config:
-      config = self.merge_dict(config, local_config['config'])
-      del local_config['config']
-    config['city'] = local_config
-    return config
+        """
+        self.db.committee.ensure_index([('originalId', ASCENDING),
+                                        ('body', ASCENDING)], unique=True)
+        # meeting
+        self.db.meeting.ensure_index([('originalId', ASCENDING),
+                                      ('body', ASCENDING)], unique=True)
+        # agendaitem
+        self.db.agendaitem.ensure_index([('originalId', ASCENDING),
+                                         ('body', ASCENDING)], unique=True)
+        # paper
+        self.db.paper.ensure_index([('originalId', ASCENDING),
+                                    ('body', ASCENDING)], unique=True)
+        # document = attachment
+        self.db.document.ensure_index([('identifier', ASCENDING),
+                                       ('body', ASCENDING)], unique=True)
+        # organization
+        self.db.organization.ensure_index([('identifier', ASCENDING),
+                                           ('body', ASCENDING)], unique=True)
+        # person
+        self.db.person.ensure_index([('originalId', ASCENDING),
+                                     ('body', ASCENDING)], unique=True)
+        # location
+        #self.db.document.ensure_index([('originalId', ASCENDING),
+                                        ('rs', ASCENDING)], unique=True)
+        #self.db.attachments.ensure_index([('originalId', ASCENDING),
+                                           ('rs', ASCENDING)], unique=True)
+        """
 
-  def dict_merge(self, a, b):
-    if not isinstance(b, dict):
-      return b
-    result = deepcopy(a)
-    for k, v in b.iteritems():
-      if k in result and isinstance(result[k], dict):
-        result[k] = self.dict_merge(result[k], v)
-      else:
-        result[k] = deepcopy(v)
-    return result
+    def erase(self):
+        """ Delete all data from database. """
+        self.db.queue.remove({})
+        self.db.agendaItem.remove({})
+        self.db.consultation.remove({})
+        self.db.file.remove({})
+        self.db.legislativeTerm.remove({})
+        self.db.location.remove({})
+        self.db.meeting.remove({})
+        self.db.membership.remove({})
+        self.db.organization.remove({})
+        self.db.paper.remove({})
+        self.db.person.remove({})
+        self.db.fs.files.remove({})
+        self.db.fs.chunks.remove({})
 
-  def save_result_string(self, result_string):
-    random_uid = uuid4()
-    self.db.body.config.scraper.result_strings.insert({'from': result_string, 'to': random_uid})
-    return random_uid
+    def get_config(self, body_uid):
+        """ Returns Config JSON """
+        config = self.db.config.find_one()
+        if '_id' in config:
+            del config['_id']
+        local_config = self.db.body.find_one({'_id': ObjectId(body_uid)})
+        if 'config' in local_config:
+            config = self.merge_dict(config, local_config['config'])
+            del local_config['config']
+        config['city'] = local_config
+        return config
 
-  def get_object(self, collection, key, value):
-    """
-    Return a document
-    """
-    result = self.db[collection].find_one({key: value,'body': DBRef('body', id=self.body_uid)})
-    return result
+    def dict_merge(self, a, b):
+        if not isinstance(b, dict):
+            return b
+        result = deepcopy(a)
+        for k, v in b.iteritems():
+            if k in result and isinstance(result[k], dict):
+                result[k] = self.dict_merge(result[k], v)
+            else:
+                result[k] = deepcopy(v)
+        return result
 
-  def get_object_id(self, collection, key, value):
-    """
-    Return the ObjectID of a document in the given collection identified
-    by the given key:value pair
-    """
-    result = self.get_object(collection, key, value)
-    if result is not None:
-      if '_id' in result:
-        return result['_id']
+    def save_result_string(self, result_string):
+        random_uid = uuid4()
+        self.db.body.config.scraper.result_strings.insert(
+            {'from': result_string, 'to': random_uid})
+        return random_uid
 
-  def meeting_exists(self, id):
-    if self.get_object_id('meeting', 'externalId', id) is not None:
-      return True
-    return False
+    def get_object(self, collection, key, value):
+        """
+        Return a document
+        """
+        result = self.db[collection].find_one(
+            {key: value, 'body': DBRef('body', id=self.body_uid)})
+        return result
 
-  def agendaItem_exists(self, id):
-    if self.get_object_id('agendaItem', 'externalId', id) is not None:
-      return True
-    return False
-  
-  def document_exists(self, id):
-    if self.get_object_id('document', 'externalId', id) is not None:
-      return True
-    return False
+    def get_object_id(self, collection, key, value):
+        """ Return the ObjectID of a document in the given collection
+        identified by the given key:value pair.
+        """
+        result = self.get_object(collection, key, value)
+        if result is not None:
+            if '_id' in result:
+                return result['_id']
 
-  def paper_exists(self, id):
-    if self.get_object_id('paper', 'externalId', id) is not None:
-      return True
-    return False
-  
-  def dereference_object(self, data_dict, attribute, datatype=False):
-    if attribute in data_dict:
-      # replace object datasets with DBRef dicts
-      if datatype:
-        save_funct = getattr(self, 'save_' + datatype)
-      else:
-        save_funct = getattr(self, 'save_' + attribute)
-        datatype = attribute
-      if isinstance(data_dict[attribute], list):
-        for n in range(len(data_dict[attribute])):
-          oid = save_funct(data_dict[attribute][n])
-          data_dict[attribute][n] = DBRef(collection=datatype, id=oid)
-      else:
-        oid = save_funct(data_dict[attribute])
-        data_dict[attribute] = DBRef(collection=datatype, id=oid)
-    return data_dict
-  
-  
-  def save_object(self, data_dict, data_stored, object_type):
-    # new object
-    if data_stored is None:
-      # insert new document
-      datatable = getattr(self.db, object_type)
-      oid = datatable.insert(data_dict)
-      logging.info("%s %s inserted as new", object_type, oid)
-      return oid
-    # update object
-    else:
-      berlin = pytz.timezone('Europe/Berlin')
-      # compare old and new dict and then send update
-      logging.info("%s %s updated with _id %s", object_type, data_dict['originalId'], data_stored['_id'])
-      set_attributes = {}
-      for key in data_dict.keys():
-        if key in ['modified', 'created']:
-          continue
-        if key not in data_stored:
-          logging.debug("Key '%s' will be added to %s", key, object_type)
-          set_attributes[key] = data_dict[key]
+    def meeting_exists(self, id):
+        if self.get_object_id('meeting', 'externalId', id) is not None:
+            return True
+        return False
+
+    def agendaItem_exists(self, id):
+        if self.get_object_id('agendaItem', 'externalId', id) is not None:
+            return True
+        return False
+
+    def document_exists(self, id):
+        if self.get_object_id('document', 'externalId', id) is not None:
+            return True
+        return False
+
+    def paper_exists(self, id):
+        if self.get_object_id('paper', 'externalId', id) is not None:
+            return True
+        return False
+
+    def dereference_object(self, data_dict, attribute, datatype=False):
+        if attribute in data_dict:
+            # replace object datasets with DBRef dicts
+            if datatype:
+                save_funct = getattr(self, 'save_' + datatype)
+            else:
+                save_funct = getattr(self, 'save_' + attribute)
+                datatype = attribute
+            if isinstance(data_dict[attribute], list):
+                for n in range(len(data_dict[attribute])):
+                    oid = save_funct(data_dict[attribute][n])
+                    data_dict[attribute][n] = DBRef(collection=datatype, id=oid)
+            else:
+                oid = save_funct(data_dict[attribute])
+                data_dict[attribute] = DBRef(collection=datatype, id=oid)
+        return data_dict
+
+    def save_object(self, data_dict, data_stored, object_type):
+        # new object
+        if data_stored is None:
+            # insert new document
+            datatable = getattr(self.db, object_type)
+            oid = datatable.insert(data_dict)
+            logging.info("%s %s inserted as new", object_type, oid)
+            return oid
+        # update object
         else:
-          # add utc info to datetime objects
-          if isinstance(data_stored[key], datetime.datetime):
-            data_stored[key] = pytz.utc.localize(data_stored[key])
-          if data_stored[key] != data_dict[key]:
-            logging.debug("Key '%s' in %s has changed", key, object_type)
-            set_attributes[key] = data_dict[key]
-      if set_attributes != {}:
-        set_attributes['modified'] = data_dict['modified']
-        datatable = getattr(self.db, object_type)
-        datatable.update({'_id': data_stored['_id']}, {'$set': set_attributes})
-      return data_stored['_id']
-  
-  def ensure_index(self, ):
-    pass
+            # compare old and new dict and then send update
+            logging.info("%s %s updated with _id %s", object_type,
+                         data_dict['originalId'], data_stored['_id'])
+            set_attributes = {}
+            for key in data_dict.keys():
+                if key in ['modified', 'created']:
+                    continue
+                if key not in data_stored:
+                    logging.debug("Key '%s' will be added to %s",
+                                  key, object_type)
+                    set_attributes[key] = data_dict[key]
+                else:
+                    # add utc info to datetime objects
+                    if isinstance(data_stored[key], datetime.datetime):
+                        data_stored[key] = pytz.utc.localize(data_stored[key])
+                    if data_stored[key] != data_dict[key]:
+                        logging.debug("Key '%s' in %s has changed",
+                                      key, object_type)
+                        set_attributes[key] = data_dict[key]
+            if set_attributes != {}:
+                set_attributes['modified'] = data_dict['modified']
+                datatable = getattr(self.db, object_type)
+                datatable.update({'_id': data_stored['_id']},
+                                 {'$set': set_attributes})
+            return data_stored['_id']
 
-  def create_slug(self, data_dict, object_type):
-    current_slug = self.slugify(data_dict['originalId'])
-    slug_counter = 0
-    while (True):
-      dataset = self.get_object(object_type, 'slug', current_slug)
-      if dataset:
-        if data_dict['originalId'] != dataset['originalId']:
-          slug_counter += 1
-          current_slug = self.slugify(data_dict['originalId']) + '-' + str(slug_counter)
+    def ensure_index(self, ):
+        pass
+
+    def create_slug(self, data_dict, object_type):
+        current_slug = self.slugify(data_dict['originalId'])
+        slug_counter = 0
+        while True:
+            dataset = self.get_object(object_type, 'slug', current_slug)
+            if dataset:
+                if data_dict['originalId'] != dataset['originalId']:
+                    slug_counter += 1
+                    current_slug = ("%s-%s"
+                                    % (self.slugify(data_dict['originalId']),
+                                       slug_counter))
+                else:
+                    return current_slug
+            else:
+                return current_slug
+
+    def save_person(self, person):
+        person_stored = self.get_object('person', 'originalId',
+                                        person.originalId)
+
+        person_dict = person.dict()
+
+        # setting body
+        person_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        # ensure that there is an originalId
+        if 'originalId' not in person_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             person_dict.originalUrl)
+
+        # dereference objects
+        person_dict = self.dereference_object(person_dict, 'membership')
+
+        # save data
+        return self.save_object(person_dict, person_stored, 'person')
+
+    def save_membership(self, membership):
+        membership_stored = self.get_object('membership', 'originalId',
+                                            membership.originalId)
+
+        membership_dict = membership.dict()
+
+        # setting body
+        membership_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        # ensure that there is an originalId
+        if 'originalId' not in membership_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             membership_dict.originalUrl)
+
+        # dereference objects
+        membership_dict = self.dereference_object(membership_dict,
+                                                  'organization')
+
+        # save data
+        return self.save_object(membership_dict, membership_stored,
+                                'membership')
+
+    def save_organization(self, organization):
+        organization_stored = self.get_object('organization', 'originalId',
+                                              organization.originalId)
+        organization_dict = organization.dict()
+
+        # setting body
+        organization_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        # ensure that there is an originalId
+        if 'originalId' not in organization_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             organization_dict.originalUrl)
+
+        # create slug
+        organization_dict['slug'] = self.create_slug(organization_dict,
+                                                     'committee')
+
+        # save data
+        return self.save_object(organization_dict, organization_stored,
+                                'organization')
+
+    def save_meeting(self, meeting):
+        """ Write meeting object to database. This means dereferencing
+        all associated objects as DBrefs.
+        """
+        meeting_stored = self.get_object('meeting', 'originalId',
+                                         meeting.originalId)
+        meeting_dict = meeting.dict()
+
+        # setting body
+        meeting_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        # ensure that there is an originalId
+        if 'originalId' not in meeting_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             meeting_dict.originalUrl)
+
+        # dereference items
+        meeting_dict = self.dereference_object(meeting_dict, 'organization')
+        meeting_dict = self.dereference_object(meeting_dict, 'agendaItem')
+        meeting_dict = self.dereference_object(meeting_dict,
+                                               'invitation', 'file')
+        meeting_dict = self.dereference_object(meeting_dict,
+                                               'resultsProtocol', 'file')
+        meeting_dict = self.dereference_object(meeting_dict,
+                                               'verbatimProtocol', 'file')
+        meeting_dict = self.dereference_object(meeting_dict,
+                                               'auxiliaryFile', 'file')
+
+        # save data
+        return self.save_object(meeting_dict, meeting_stored, 'meeting')
+
+    def save_agendaItem(self, agendaitem):
+        """ Write agendaitem object to database. This means
+        dereferencing all associated objects as DBrefs.
+        """
+        agendaitem_stored = self.get_object('agendaItem', 'originalId',
+                                            agendaitem.originalId)
+        agendaitem_dict = agendaitem.dict()
+
+        # setting body
+        agendaitem_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        if 'originalId' not in agendaitem_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             agendaitem_dict.originalUrl)
+
+        # dereference items
+        agendaitem_dict = self.dereference_object(agendaitem_dict, 'consultation')
+
+        return self.save_object(agendaitem_dict, agendaitem_stored, 'agendaItem')
+
+    def save_consultation(self, consultation):
+        """ Write consultation object to database. This means
+        dereferencing all associated objects as DBrefs.
+        """
+        consultation_stored = self.get_object('consultation', 'originalId',
+                                              consultation.originalId)
+        consultation_dict = consultation.dict()
+
+        # setting body
+        consultation_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        if 'originalId' not in consultation_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             consultation_dict.originalUrl)
+
+        # dereference items
+        consultation_dict = self.dereference_object(consultation_dict,
+                                                    'agendaItem', 'agendaItem')
+        consultation_dict = self.dereference_object(consultation_dict,
+                                                    'paper')
+        consultation_dict = self.dereference_object(consultation_dict,
+                                                    'meeting', 'meeting')
+
+        return self.save_object(consultation_dict, consultation_stored,
+                                'consultation')
+
+    def save_paper(self, paper):
+        """Write paper to DB and return ObjectID"""
+        paper_stored = self.get_object('paper', 'originalId', paper.originalId)
+        paper_dict = paper.dict()
+
+        paper_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        if 'originalId' not in paper_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             paper_dict.originalUrl)
+
+        # dereference items
+        paper_dict = self.dereference_object(paper_dict,
+                                             'relatedPaper', 'paper')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'mainFile', 'file')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'auxiliaryFile', 'file')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'originator', 'organization')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'underDirectionOf', 'organization')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'superordinatedPaper', 'paper')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'subordinatedPaper', 'paper')
+        paper_dict = self.dereference_object(paper_dict,
+                                             'consultation', 'consultation')
+
+        return self.save_object(paper_dict, paper_stored, 'paper')
+
+
+    def save_file(self, file_obj):
+        """
+        Write file to DB and return ObjectID.
+        - If the file already exists, the existing file
+            is updated in the database.
+        - If the file_obj.content has changed, a new GridFS file version
+            is added.
+        - If file_obj is depublished, no new file is stored.
+        """
+        file_stored = self.get_object('file', 'originalId', file_obj.originalId)
+        file_dict = file_obj.dict()
+
+        file_dict['body'] = DBRef(collection='body', id=self.body_uid)
+
+        if 'originalId' not in file_dict:
+            logging.critical("Fatal error: no originalId avaiable at url %s",
+                             paper_dict.originalUrl)
+
+        file_dict = self.dereference_object(file_dict, 'masterFile', 'file')
+
+        file_changed = False
+        if file_stored is not None:
+            # file exists in database and must be compared field by field
+            logging.info("file %s is already in db with _id=%s",
+                         file_obj.originalId, file_stored['_id'])
+            # check if file is referenced
+            file_data_stored = None
+            if 'file' in file_stored:
+                # assuming DBRef in file_obj.file
+                assert isinstance(file_stored['file'], DBRef)
+                file_data_stored = self.db.fs.files.find_one(
+                    {'_id': file_stored['file'].id})
+            if file_data_stored is not None and file_obj.content:
+                # compare stored and submitted file
+                if file_data_stored['length'] != len(file_obj.content):
+                    file_changed = True
+                elif file_data_stored['md5'] != md5(
+                        file_obj.content).hexdigest():
+                    file_changed = True
+            if file_data_stored is None and file_obj.content:
+                file_changed = True
+
+        # Create new file version (if necessary)
+        if ((file_changed and 'depublication' not in file_stored)
+                or (file_stored is None)) and file_obj.content:
+            file_oid = self.fs.put(file_obj.content,
+                                   filename=file_obj.filename,
+                                   body=DBRef('body', self.body_uid))
+            logging.info("New file version stored with _id=%s", file_oid)
+            file_dict['file'] = DBRef(collection='fs.files', id=file_oid)
+
+        # erase file content (since stored elsewhere above)
+        if 'content' in file_dict:
+            del file_dict['content']
+
+        oid = None
+        if file_stored is None:
+            # insert new
+            oid = self.db.file.insert(file_dict)
+            logging.info("File %s inserted with _id %s",
+                         file_obj.originalId, oid)
         else:
-          return current_slug
-      else:
-        return current_slug
+            # Only do partial update
+            oid = file_stored['_id']
+            set_attributes = {}
+            for key in file_dict.keys():
+                if key in ['modified', 'created']:
+                    continue
+                if key not in file_stored:
+                    set_attributes[key] = file_dict[key]
+                else:
+                    # add utc info to datetime objects
+                    if isinstance(file_stored[key], datetime.datetime):
+                        file_stored[key] = pytz.utc.localize(file_stored[key])
+                    if file_stored[key] != file_dict[key]:
+                        logging.debug("Key '%s' will be updated", key)
+                        set_attributes[key] = file_dict[key]
+            if 'file' not in file_dict and 'file' in file_stored:
+                set_attributes['file'] = file_stored['file']
+            if file_changed or set_attributes != {}:
+                set_attributes['modified'] = file_dict['modified']
+                self.db.file.update({'_id': oid}, {'$set': set_attributes})
+        return oid
 
-  def save_person(self, person):
-    person_stored = self.get_object('person', 'originalId', person.originalId)
-    
-    person_dict = person.dict()
-    
-    # setting body
-    person_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    # ensure that there is an originalId
-    if 'originalId' not in person_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", person_dict.originalUrl)
-    
-    # dereference objects
-    person_dict = self.dereference_object(person_dict, 'membership')
-    
-    # save data
-    return self.save_object(person_dict, person_stored, 'person')
+    def slugify(self, identifier):
+        identifier = unicode(identifier)
+        identifier = identifier.replace('/', '-')
+        identifier = identifier.replace(' ', '-')
+        result = []
+        for word in self.slugify_re.split(identifier.lower()):
+            word = word.encode('translit/long')
+            if word:
+                result.append(word)
+        return unicode('-'.join(result))
 
-  def save_membership(self, membership):
-    membership_stored = self.get_object('membership', 'originalId', membership.originalId)
-    
-    membership_dict = membership.dict()
-    
-    # setting body
-    membership_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    # ensure that there is an originalId
-    if 'originalId' not in membership_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", membership_dict.originalUrl)
-    
-    # dereference objects
-    membership_dict = self.dereference_object(membership_dict, 'organization')
-    
-    # save data
-    return self.save_object(membership_dict, membership_stored, 'membership')
+    def queue_status(self):
+        """
+        Prints out information on the queue
+        """
+        aggregate = self.db.queue.aggregate([
+            {
+                "$group": {
+                    "_id": {
+                        "rs": "$rs",
+                        "status": "$status",
+                        "qname": "$qname"
+                    },
+                    "count": {"$sum": 1}
+                }
+            },
+            {
+                "$sort": {"_id.rs": 1}
+            }])
+        rs = None
+        for entry in aggregate['result']:
+            logging.info("Queue %s, status %s: %d jobs", entry['_id']['qname'],
+                         entry['_id']['status'], entry['count'])
 
-  def save_organization(self, organization):
-    organization_stored = self.get_object('organization', 'originalId', organization.originalId)
-    organization_dict = organization.dict()
-    
-    # setting body
-    organization_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    # ensure that there is an originalId
-    if 'originalId' not in organization_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", organization_dict.originalUrl)
-    
-    # create slug
-    organization_dict['slug'] = self.create_slug(organization_dict, 'committee')
-    
-    # save data
-    return self.save_object(organization_dict, organization_stored, 'organization')
-  
-  def save_meeting(self, meeting):
-    """
-    Write meeting object to database. This means dereferencing all associated objects as DBrefs
-    """
-    meeting_stored = self.get_object('meeting', 'originalId', meeting.originalId)
-    meeting_dict = meeting.dict()
-
-    # setting body
-    meeting_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    # ensure that there is an originalId
-    if 'originalId' not in meeting_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", meeting_dict.originalUrl)
-    
-    # dereference items
-    meeting_dict = self.dereference_object(meeting_dict, 'organization')
-    meeting_dict = self.dereference_object(meeting_dict, 'agendaItem')
-    meeting_dict = self.dereference_object(meeting_dict, 'invitation', 'file')
-    meeting_dict = self.dereference_object(meeting_dict, 'resultsProtocol', 'file')
-    meeting_dict = self.dereference_object(meeting_dict, 'verbatimProtocol', 'file')
-    meeting_dict = self.dereference_object(meeting_dict, 'auxiliaryFile', 'file')
-    
-    # save data
-    return self.save_object(meeting_dict, meeting_stored, 'meeting')
-
-  
-  def save_agendaItem(self, agendaitem):
-    """
-    Write agendaitem object to database. This means dereferencing all associated objects as DBrefs
-    """
-    agendaitem_stored = self.get_object('agendaItem', 'originalId', agendaitem.originalId)
-    agendaitem_dict = agendaitem.dict()
-
-    # setting body
-    agendaitem_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    if 'originalId' not in agendaitem_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", agendaitem_dict.originalUrl)
-    
-    # dereference items
-    agendaitem_dict = self.dereference_object(agendaitem_dict, 'consultation')
-
-    return self.save_object(agendaitem_dict, agendaitem_stored, 'agendaItem')
-  
-  def save_consultation(self, consultation):
-    """
-    Write consultation object to database. This means dereferencing all associated objects as DBrefs
-    """
-    consultation_stored = self.get_object('consultation', 'originalId', consultation.originalId)
-    consultation_dict = consultation.dict()
-
-    # setting body
-    consultation_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    if 'originalId' not in consultation_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", consultation_dict.originalUrl)
-    
-    # dereference items
-    consultation_dict = self.dereference_object(consultation_dict, 'agendaItem', 'agendaItem')
-    consultation_dict = self.dereference_object(consultation_dict, 'paper')
-    consultation_dict = self.dereference_object(consultation_dict, 'meeting', 'meeting')
-
-    return self.save_object(consultation_dict, consultation_stored, 'consultation')
-
-  def save_paper(self, paper):
-    """Write paper to DB and return ObjectID"""
-    paper_stored = self.get_object('paper', 'originalId', paper.originalId)
-    paper_dict = paper.dict()
-
-    paper_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    if 'originalId' not in paper_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", paper_dict.originalUrl)
-    
-    # dereference items
-    paper_dict = self.dereference_object(paper_dict, 'relatedPaper', 'paper')
-    paper_dict = self.dereference_object(paper_dict, 'mainFile', 'file')
-    paper_dict = self.dereference_object(paper_dict, 'auxiliaryFile', 'file')
-    paper_dict = self.dereference_object(paper_dict, 'originator', 'organization')
-    paper_dict = self.dereference_object(paper_dict, 'underDirectionOf', 'organization')
-    paper_dict = self.dereference_object(paper_dict, 'superordinatedPaper', 'paper')
-    paper_dict = self.dereference_object(paper_dict, 'subordinatedPaper', 'paper')
-    paper_dict = self.dereference_object(paper_dict, 'consultation', 'consultation')
-    
-    return self.save_object(paper_dict, paper_stored, 'paper')
-  
-  
-  def save_file(self, file):
-    """
-    Write file to DB and return ObjectID.
-    - If the file already exists, the existing file
-      is updated in the database.
-    - If the file.content has changed, a new GridFS file version
-      is added.
-    - If file is depublished, no new file is stored.
-    """
-    file_stored = self.get_object('file', 'originalId', file.originalId)
-    file_dict = file.dict()
-    
-    file_dict['body'] = DBRef(collection='body',id=self.body_uid)
-    
-    if 'originalId' not in file_dict:
-      logging.critical("Fatal error: no originalId avaiable at url %s", paper_dict.originalUrl)
-
-    file_dict = self.dereference_object(file_dict, 'masterFile', 'file')
-    
-    file_changed = False
-    if file_stored is not None:
-      # file exists in database and must be compared field by field
-      logging.info("file %s is already in db with _id=%s", file.originalId, str(file_stored['_id']))
-      # check if file is referenced
-      file_data_stored = None
-      if 'file' in file_stored:
-        # assuming DBRef in file.file
-        assert type(file_stored['file']) == DBRef
-        file_data_stored = self.db.fs.files.find_one({'_id': file_stored['file'].id})
-      if file_data_stored is not None and file.content:
-        # compare stored and submitted file
-        if file_data_stored['length'] != len(file.content):
-          file_changed = True
-        elif file_data_stored['md5'] != md5(file.content).hexdigest():
-          file_changed = True
-      if file_data_stored is None and file.content:
-        file_changed = True
-    
-    # Create new file version (if necessary)
-    if ((file_changed and 'depublication' not in file_stored) or (file_stored is None)) and file.content:
-      file_oid = self.fs.put(file.content,
-        filename=file.filename,
-        body=DBRef('body', self.body_uid))
-      logging.info("New file version stored with _id=%s", str(file_oid))
-      file_dict['file'] = DBRef(collection='fs.files', id=file_oid)
-
-    # erase file content (since stored elsewhere above)
-    if 'content' in file_dict:
-      del file_dict['content']
-    
-    oid = None
-    if file_stored is None:
-      # insert new
-      oid = self.db.file.insert(file_dict)
-      logging.info("File %s inserted with _id %s", file.originalId, str(oid))
-    else:
-      # Only do partial update
-      oid = file_stored['_id']
-      set_attributes = {}
-      for key in file_dict.keys():
-        if key in ['modified', 'created']:
-          continue
-        if key not in file_stored:
-          set_attributes[key] = file_dict[key]
-        else:
-          # add utc info to datetime objects
-          if isinstance(file_stored[key], datetime.datetime):
-            file_stored[key] = pytz.utc.localize(file_stored[key])
-          if file_stored[key] != file_dict[key]:
-            logging.debug("Key '%s' will be updated", key)
-            set_attributes[key] = file_dict[key]
-      if 'file' not in file_dict and 'file' in file_stored:
-          set_attributes['file'] = file_stored['file']
-      if file_changed or set_attributes != {}:
-        set_attributes['modified'] = file_dict['modified']
-        self.db.file.update({'_id': oid}, {'$set': set_attributes})
-    return oid
-
-  def slugify(self, identifier):
-    identifier = unicode(identifier)
-    identifier = identifier.replace('/', '-')
-    identifier = identifier.replace(' ', '-')
-    result = []
-    for word in self.slugify_re.split(identifier.lower()):
-      word = word.encode('translit/long')
-      if word:
-        result.append(word)
-    return unicode('-'.join(result))
-  
-  def queue_status(self):
-    """
-    Prints out information on the queue
-    """
-    aggregate = self.db.queue.aggregate([
-      {
-        "$group": {
-          "_id": {
-            "rs": "$rs",
-            "status": "$status",
-            "qname": "$qname"
-          },
-          "count": {"$sum": 1}
-        }
-      },
-      {
-        "$sort": {"_id.rs": 1}
-      }])
-    rs = None
-    for entry in aggregate['result']:
-      logging.info("Queue %s, status %s: %d jobs", entry['_id']['qname'], entry['_id']['status'], entry['count'])
-
-  def merge_dict(self, x, y):
-    merged = dict(x,**y)
-    xkeys = x.keys()
-    for key in xkeys:
-      if type(x[key]) is types.DictType and y.has_key(key):
-        merged[key] = self.merge_dict(x[key],y[key])
-    return merged
+    def merge_dict(self, x, y):
+        merged = dict(x, **y)
+        xkeys = x.keys()
+        for key in xkeys:
+            if isinstance(x[key], types.DictType) and y.has_key(key):
+                merged[key] = self.merge_dict(x[key], y[key])
+        return merged

--- a/main.py
+++ b/main.py
@@ -4,190 +4,241 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import argparse
-from risscraper.scrapersessionnet import ScraperSessionNet
-from risscraper.scraperallris import ScraperAllRis
-import inspect
-import os
-import datetime
-import sys
-import importlib
-import logging
 import calendar
+import datetime
+import inspect
+import logging
+import os
+import sys
+
+from risscraper.scraperallris import ScraperAllRis
+from risscraper.scrapersessionnet import ScraperSessionNet
+
 import config as db_config
 
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"city")))
-if cmd_subfolder not in sys.path:
-  sys.path.insert(0, cmd_subfolder)
+CMD_SUBFOLDER = os.path.realpath(os.path.abspath(os.path.join(os.path.split(
+    inspect.getfile(inspect.currentframe()))[0], "city")))
+if CMD_SUBFOLDER not in sys.path:
+    sys.path.insert(0, CMD_SUBFOLDER)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Scrape Dein Ratsinformationssystem')
+    parser.add_argument('--body', '-b', dest='body_uid', required=True,
+                        help=("UID of the body"))
+    parser.add_argument('--interactive', '-i', default=0, dest="interactive",
+                        help=("Interactive mode: brings messages above given "
+                              "level to stdout"))
+    parser.add_argument('--queue', '-q', dest="workfromqueue",
+                        action="store_true", default=False,
+                        help=('Set this flag to activate "greedy" scraping. '
+                              'This means that links from sessions to '
+                              'submissions are followed. This is implied '
+                              'if --start is given, otherwise it is off by '
+                              'default.'))
+    # date
+    parser.add_argument('--start', dest="start_month", default=False,
+                        help=('Find sessions and related content starting in '
+                              'this month. Format: "YYYY-MM". When this is '
+                              'used, the -q parameter is implied.'))
+    parser.add_argument('--end', dest="end_month", default=False,
+                        help=('Find sessions and related content up to this '
+                              'month. Requires --start parameter to be set, '
+                              'too. Format: "YYYY-MM"'))
+    # organization
+    parser.add_argument('--organizationid', dest="organization_id",
+                        default=False, help='Scrape a specific organization, '
+                                            'identified by its numeric ID')
+    parser.add_argument('--organizationurl', dest="organization_url",
+                        default=False, help='Scrape a specific organization, '
+                                            'identified by its detail page URL')
+    # person
+    parser.add_argument('--personid', dest="person_id", default=False,
+                        help='Scrape a specific person, identified by its '
+                             'numeric ID')
+    parser.add_argument('--personurl', dest="person_url", default=False,
+                        help='Scrape a specific person, identified by its '
+                             'detail page URL')
+    # meeting
+    parser.add_argument('--meetingid', dest="meeting_id", default=False,
+                        help='Scrape a specific meeting, identified by its '
+                             'numeric ID')
+    parser.add_argument('--meetingurl', dest="meeting_url", default=False,
+                        help='Scrape a specific meeting, identified by its '
+                             'detail page URL')
+    # paper
+    parser.add_argument('--paperid', dest="paper_id", default=False,
+                        help='Scrape a specific paper, identified by its '
+                             'numeric ID')
+    parser.add_argument('--paperurl', dest="paper_url", default=False,
+                        help='Scrape a specific paper, identified by its '
+                             'detail page URL')
+
+    parser.add_argument('--erase', dest="erase_db", action="store_true",
+                        default=False, help='Erase all database content '
+                                            'before start. Caution!')
+    parser.add_argument('--status', dest="status", action="store_true",
+                        default=False, help='Print out queue status')
+    options = parser.parse_args()
+
+    # setup db
+    db = None
+    if db_config.DB_TYPE == 'mongodb':
+        import db.mongodb
+        db = db.mongodb.MongoDatabase(db_config)
+        config = db.get_config(options.body_uid)
+        db.setup(config)
+
+    # set up logging
+    logfile = 'scrapearis.log'
+    if config['scraper']['log_base_dir'] is not None:
+        now = datetime.datetime.utcnow()
+        logfile = '%s/%s-%s.log' % (config['scraper']['log_base_dir'],
+                                    config['city']['_id'],
+                                    now.strftime('%Y%m%d-%H%M'))
+    levels = {
+        'DEBUG': logging.DEBUG,
+        'INFO': logging.INFO,
+        'WARNING': logging.WARNING,
+        'ERROR': logging.ERROR,
+        'CRITICAL': logging.CRITICAL
+    }
+    loglevel = 'INFO'
+    if config['scraper']['log_level'] is not None:
+        loglevel = config['scraper']['log_level']
+    logging.basicConfig(
+        filename=logfile, level=levels[loglevel],
+        format='%(asctime)s %(name)s %(levelname)s %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S')
+
+    # prevent "Starting new HTTP connection (1):" INFO messages from requests
+    requests_log = logging.getLogger("requests")
+    requests_log.setLevel(logging.WARNING)
+
+    # interactive logging
+    if options.interactive in levels:
+        root = logging.getLogger()
+        ch = logging.StreamHandler(sys.stdout)
+        ch.setLevel(levels[options.interactive])
+        formatter = logging.Formatter('%(levelname)s: %(message)s')
+        ch.setFormatter(formatter)
+        root.addHandler(ch)
+
+    logging.info('Starting scraper with configuration from "%s" and loglevel "%s"',
+                 config['city']['_id'], loglevel)
+
+    # queue status
+    if options.status:
+        db.queue_status()
+
+    # erase db
+    if options.erase_db:
+        print "Erasing database"
+        db.erase()
+
+    if options.start_month:
+        try:
+            options.start_month = datetime.datetime.strptime(
+                options.start_month, '%Y-%m')
+        except ValueError:
+            sys.stderr.write("Bad format or invalid month for --start "
+                             "parameter. Use 'YYYY-MM'.\n")
+            sys.exit()
+        if options.end_month:
+            try:
+                options.end_month = datetime.datetime.strptime(
+                    "%s-%s" % (options.end_month, calendar.monthrange(
+                        int(options.end_month[0:4]),
+                        int(options.end_month[5:7]))[1]),
+                    '%Y-%m-%d')
+            except ValueError:
+                sys.stderr.write("Bad format or invalid month for --end "
+                                 "parameter. Use 'YYYY-MM'.\n")
+                sys.exit()
+            if options.end_month < options.start_month:
+                sys.stderr.write("Error with --start and --end parameter: end "
+                                 "month should be after start month.\n")
+                sys.exit()
+        else:
+            options.end_month = options.start_month
+        options.workfromqueue = True
+
+    # TODO: Autodetect basic type
+    if ((config['scraper']['type'] == 'sessionnet-asp')
+            or (config['scraper']['type'] == 'sessionnet-php')):
+        scraper = ScraperSessionNet(config, db, options)
+    elif config['scraper']['type'] == 'allris':
+        scraper = ScraperAllRis(config, db, options)
+
+    scraper.guess_system()
+    # person
+    if options.person_id:
+        #scraper.find_person() #should be part of scraper
+        #scraper.get_person(person_id=int(options.person_id))
+        # should be part of scraper
+        scraper.get_person_organization(person_id=int(options.person_id))
+    if options.person_url:
+        #scraper.find_person() #should be part of scraper
+        #scraper.get_person(person_url=options.person_url)
+        # should be part of scraper
+        scraper.get_person_organization(person_url=options.person_url)
+    # organization
+    if options.organization_id:
+        scraper.get_organization(organization_id=int(options.organization_id))
+    if options.organization_url:
+        scraper.get_organization(organization_url=options.organization_url)
+    # meeting
+    if options.meeting_id:
+        scraper.get_meeting(meeting_id=int(options.meeting_id))
+    if options.meeting_url:
+        scraper.get_meeting(meeting_url=options.meeting_url)
+    # paper
+    if options.paper_id:
+        scraper.get_paper(paper_id=int(options.paper_id))
+    if options.paper_url:
+        scraper.get_paper(paper_url=options.paper_url)
+
+
+    if options.start_month:
+        scraper.find_person()
+        scraper.find_meeting(start_date=options.start_month,
+                             end_date=options.end_month)
+
+    if options.workfromqueue:
+        scraper.work_from_queue()
+
+    logging.info('Scraper finished.')
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-    description='Scrape Dein Ratsinformationssystem')
-  parser.add_argument('--body', '-b', dest='body_uid', required=True,
-    help=("UID of the body"))
-  parser.add_argument('--interactive', '-i', default=0, dest="interactive",
-    help=("Interactive mode: brings messages above given level to stdout"))
-  parser.add_argument('--queue', '-q', dest="workfromqueue", action="store_true",
-    default=False, help=('Set this flag to activate "greedy" scraping. This means that ' +
-    'links from sessions to submissions are followed. This is implied ' +
-    'if --start is given, otherwise it is off by default.'))
-  # date
-  parser.add_argument('--start', dest="start_month",
-    default=False, help=('Find sessions and related content starting in this month. ' +
-    'Format: "YYYY-MM". When this is used, the -q parameter is implied.'))
-  parser.add_argument('--end', dest="end_month",
-    default=False, help=('Find sessions and related content up to this month. ' +
-    'Requires --start parameter to be set, too. Format: "YYYY-MM"'))
-  # organization
-  parser.add_argument('--organizationid', dest="organization_id",
-    default=False, help='Scrape a specific organization, identified by its numeric ID')
-  parser.add_argument('--organizationurl', dest="organization_url",
-    default=False, help='Scrape a specific organization, identified by its detail page URL')
-  # person
-  parser.add_argument('--personid', dest="person_id",
-    default=False, help='Scrape a specific person, identified by its numeric ID')
-  parser.add_argument('--personurl', dest="person_url",
-    default=False, help='Scrape a specific person, identified by its detail page URL')
-  # meeting
-  parser.add_argument('--meetingid', dest="meeting_id",
-    default=False, help='Scrape a specific meeting, identified by its numeric ID')
-  parser.add_argument('--meetingurl', dest="meeting_url",
-    default=False, help='Scrape a specific meeting, identified by its detail page URL')
-  # paper
-  parser.add_argument('--paperid', dest="paper_id",
-    default=False, help='Scrape a specific paper, identified by its numeric ID')
-  parser.add_argument('--paperurl', dest="paper_url",
-    default=False, help='Scrape a specific paper, identified by its detail page URL')
-  
-  parser.add_argument('--erase', dest="erase_db", action="store_true",
-    default=False, help='Erase all database content before start. Caution!')
-  parser.add_argument('--status', dest="status", action="store_true",
-    default=False, help='Print out queue status')
-  options = parser.parse_args()
-
-  # setup db
-  db = None
-  if db_config.DB_TYPE == 'mongodb':
-    import db.mongodb
-    db = db.mongodb.MongoDatabase(db_config)
-    config = db.get_config(options.body_uid)
-    db.setup(config)
-  
-  # set up logging
-  logfile = 'scrapearis.log'
-  if config['scraper']['log_base_dir'] is not None:
-    now = datetime.datetime.utcnow()
-    logfile = '%s/%s-%s.log' % (config['scraper']['log_base_dir'], config['city']['_id'], now.strftime('%Y%m%d-%H%M'))
-  levels = {
-    'DEBUG': logging.DEBUG,
-    'INFO': logging.INFO,
-    'WARNING': logging.WARNING,
-    'ERROR': logging.ERROR,
-    'CRITICAL': logging.CRITICAL
-  }
-  loglevel = 'INFO'
-  if config['scraper']['log_level'] is not None:
-    loglevel = config['scraper']['log_level']
-  logging.basicConfig(
-    filename=logfile,
-    level=levels[loglevel],
-    format='%(asctime)s %(name)s %(levelname)s %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S')
-  
-  # prevent "Starting new HTTP connection (1):" INFO messages from requests
-  requests_log = logging.getLogger("requests")
-  requests_log.setLevel(logging.WARNING)
-  
-  # interactive logging
-  if options.interactive in levels:
-    root = logging.getLogger()
-    ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(levels[options.interactive])
-    formatter = logging.Formatter('%(levelname)s: %(message)s')
-    ch.setFormatter(formatter)
-    root.addHandler(ch)
-  
-  logging.info('Starting scraper with configuration from "%s" and loglevel "%s"', config['city']['_id'], loglevel)
-
-
-  # queue status
-  if options.status:
-    db.queue_status()
-
-  # erase db
-  if options.erase_db:
-    print "Erasing database"
-    db.erase()
-  
-  if options.start_month:
-    try:
-      options.start_month = datetime.datetime.strptime(options.start_month, '%Y-%m')
-    except ValueError:
-      sys.stderr.write("Bad format or invalid month for --start parameter. Use 'YYYY-MM'.\n")
-      sys.exit()
-    if options.end_month:
-      try:
-        options.end_month = datetime.datetime.strptime("%s-%s" % (options.end_month, calendar.monthrange(int(options.end_month[0:4]), int(options.end_month[5:7]))[1]), '%Y-%m-%d')
-      except ValueError:
-        sys.stderr.write("Bad format or invalid month for --end parameter. Use 'YYYY-MM'.\n")
-        sys.exit()
-      if options.end_month < options.start_month:
-        sys.stderr.write("Error with --start and --end parameter: end month should be after start month.\n")
-        sys.exit()
-    else:
-      options.end_month = options.start_month
-    options.workfromqueue = True
-  
-  # TODO: Autodetect basic type
-  if config['scraper']['type'] == 'sessionnet-asp' or config['scraper']['type'] == 'sessionnet-php':
-    scraper = ScraperSessionNet(config, db, options)
-  elif config['scraper']['type'] == 'allris':
-    scraper = ScraperAllRis(config, db, options)
-  
-  scraper.guess_system()
-  # person
-  if options.person_id:
-    #scraper.find_person() #should be part of scraper
-    #scraper.get_person(person_id=int(options.person_id))
-    scraper.get_person_organization(person_id=int(options.person_id)) #should be part of scraper
-  if options.person_url:
-    #scraper.find_person() #should be part of scraper
-    #scraper.get_person(person_url=options.person_url)
-    scraper.get_person_organization(person_url=options.person_url) #should be part of scraper
-  # organization
-  if options.organization_id:
-    scraper.get_organization(organization_id=int(options.organization_id))
-  if options.organization_url:
-    scraper.get_organization(organization_url=options.organization_url)
-  # meeting
-  if options.meeting_id:
-    scraper.get_meeting(meeting_id=int(options.meeting_id))
-  if options.meeting_url:
-    scraper.get_meeting(meeting_url=options.meeting_url)
-  # paper
-  if options.paper_id:
-    scraper.get_paper(paper_id=int(options.paper_id))
-  if options.paper_url:
-    scraper.get_paper(paper_url=options.paper_url)
-
-
-  if options.start_month:
-    scraper.find_person()
-    scraper.find_meeting(start_date=options.start_month, end_date=options.end_month)
-
-  if options.workfromqueue:
-    scraper.work_from_queue()
-
-  logging.info('Scraper finished.')
+    main()

--- a/risscraper/model/agendaitem.py
+++ b/risscraper/model/agendaitem.py
@@ -4,42 +4,60 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
-import filters
 
 
 class AgendaItem(Base):
-  """
-  A agendaitem class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               meeting=None, number=None, name=None, public=None, consultation=None, result=None,
-               resolution=None, auxiliaryFile=None):
-    self.body = body
-    self.originalId = originalId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.meeting = meeting #generated(?)
-    self.number = number
-    self.name = name
-    self.public = public
-    self.consultation = consultation
-    self.result = result
-    self.resolution = resolution
-    self.auxiliaryFile = auxiliaryFile #list of file
-    
-    super(AgendaItem, self).__init__()
+    """ An agendaitem class """
+
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, meeting=None,
+                 number=None, name=None, public=None, consultation=None,
+                 result=None, resolution=None, auxiliaryFile=None):
+        self.body = body
+        self.originalId = originalId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
+
+        # generated(?)
+        self.meeting = meeting
+        self.number = number
+        self.name = name
+        self.public = public
+        self.consultation = consultation
+        self.result = result
+        self.resolution = resolution
+        # list of file
+        self.auxiliaryFile = auxiliaryFile
+
+        super(AgendaItem, self).__init__()

--- a/risscraper/model/base.py
+++ b/risscraper/model/base.py
@@ -4,77 +4,92 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import datetime
-import filters
-import sys
 
 
 class Base(object):
-  """
-  A base object
-  """
+    """
+    A base object
+    """
 
-  def __init__(self):
-    self._filters = []
-    #{
-    #  'fieldname': 'identifier',
-    #  'filter': lambda x: filters.remove_whitespace(x)
-    #}]
-    self._required_fields = []
-    self._enforced_types = {}
-    self._defaults = {
-      'modified': datetime.datetime.utcnow(),
-      'created': datetime.datetime.utcnow(),
-    }
-    self.apply_defaults()
-    #self.apply_filters()
+    def __init__(self):
+        self._filters = []
+        #{
+        #    'fieldname': 'identifier',
+        #    'filter': lambda x: filters.remove_whitespace(x)
+        #}]
+        self._required_fields = []
+        self._enforced_types = {}
+        self._defaults = {
+            'modified': datetime.datetime.utcnow(),
+            'created': datetime.datetime.utcnow(),
+        }
+        self.apply_defaults()
+        #self.apply_filters()
 
-  def dict(self):
-    self.apply_filters()
-    out = {}
-    for key in dir(self):
-      if key.startswith('_'):
-        continue
-      val = getattr(self, key)
-      if callable(val):
-        continue
-      if val is None:
-        continue
-      outkey = key
-      if outkey.startswith('x_'):
-        outkey = outkey[2:]
-      out[outkey] = val
-    return out
+    def dict(self):
+        self.apply_filters()
+        out = {}
+        for key in dir(self):
+            if key.startswith('_'):
+                continue
+            val = getattr(self, key)
+            if callable(val):
+                continue
+            if val is None:
+                continue
+            outkey = key
+            if outkey.startswith('x_'):
+                outkey = outkey[2:]
+            out[outkey] = val
+        return out
 
-  def apply_defaults(self):
-    for key in self._defaults.keys():
-      if key in dir(self):
-        if getattr(self, key) is None:
-          setattr(self, key, self._defaults[key])
-      else:
-        setattr(self, key, self._defaults[key])
+    def apply_defaults(self):
+        for key in self._defaults.keys():
+            if key in dir(self):
+                if getattr(self, key) is None:
+                    setattr(self, key, self._defaults[key])
+            else:
+                setattr(self, key, self._defaults[key])
 
-  def apply_filters(self):
-    for key in dir(self):
-      if key.startswith('_'):
-        continue
-      value = getattr(self, key)
-      if callable(value):
-        continue
-      if value is None:
-        continue
-      for flt in self._filters:
-        if key == flt['fieldname']:
-          value = flt['filter'](value)
-          setattr(self, key, value)
+    def apply_filters(self):
+        for key in dir(self):
+            if key.startswith('_'):
+                continue
+            value = getattr(self, key)
+            if callable(value):
+                continue
+            if value is None:
+                continue
+            for flt in self._filters:
+                if key == flt['fieldname']:
+                    value = flt['filter'](value)
+                    setattr(self, key, value)

--- a/risscraper/model/body.py
+++ b/risscraper/model/body.py
@@ -4,52 +4,69 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
-import filters
 
 
 class Body(Base):
-  """
-  A body class
-  """
-  def __init__(self, identifier=None, rgs=None, name=None, modified=None):
-    self.identifier = identifier
-    self.originalId = numericId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    
-    self.system = system
-    self.shortName = shortName
-    self.name = name
-    self.website = website
-    self.license = license
-    self.licenseValidSince = licenseValidSince
-    self.ags = ags
-    self.rgs = rgs
-    self.equivalentBody = equivalentBody #list
-    self.contactEmail = contactEmail
-    self.contactName = contactName
-    # organization
-    # person
-    # meeting
-    # agendaitem
-    # paper
-    # file
-    # consultation
-    # location
-    # membership
-    # legislativeTerm
-    self.classification = classification
-    super(Body, self).__init__()
+    """ A body class """
+
+    def __init__(self, identifier=None, rgs=None, name=None, modified=None):
+        # TODO: lots of variables ar missing - is "Body" still in use?
+        self.identifier = identifier
+        self.originalId = numericId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+
+        self.system = system
+        self.shortName = shortName
+        self.name = name
+        self.website = website
+        self.license = license
+        self.licenseValidSince = licenseValidSince
+        self.ags = ags
+        self.rgs = rgs
+        # list
+        self.equivalentBody = equivalentBody
+        self.contactEmail = contactEmail
+        self.contactName = contactName
+        # organization
+        # person
+        # meeting
+        # agendaitem
+        # paper
+        # file
+        # consultation
+        # location
+        # membership
+        # legislativeTerm
+        self.classification = classification
+        super(Body, self).__init__()

--- a/risscraper/model/consultation.py
+++ b/risscraper/model/consultation.py
@@ -4,41 +4,60 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
-import filters
 
 
 class Consultation(Base):
-  """
-  A consultation class
-  """
-  def __init__(self, body=None, originalId=None, originalUrl=None, created=None, modified=None, keyword=None,
-               paper=None, agendaItem=None, meeting=None, organization=None, authoritative=None, role=None, status=None):
-    self.body = body
-    self.originalId = originalId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword #list
-    
-    self.paper = paper
-    self.agendaItem = agendaItem
-    self.meeting = meeting # backref
-    self.organization = organization #list
-    self.authoritative = authoritative
-    self.role = role
-    self.status = status #non-oparl
-    super(Consultation, self).__init__()
+    """ A consultation class """
 
+    def __init__(self, body=None, originalId=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, paper=None,
+                 agendaItem=None, meeting=None, organization=None,
+                 authoritative=None, role=None, status=None):
+        self.body = body
+        self.originalId = originalId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        # list
+        self.keyword = keyword
 
+        self.paper = paper
+        self.agendaItem = agendaItem
+        # backref
+        self.meeting = meeting
+        # list
+        self.organization = organization
+        self.authoritative = authoritative
+        self.role = role
+        # non-oparl
+        self.status = status
+        super(Consultation, self).__init__()

--- a/risscraper/model/file.py
+++ b/risscraper/model/file.py
@@ -4,68 +4,91 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from base import Base
 import hashlib
+
+from base import Base
 
 
 class File(Base):
-  """
-  An file class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               name=None, fileName=None, paper=None, mimeType=None, date=None, sha1Checksum=None,
-               size=None, text=None, accessUrl=None, downloadUrl=None, masterDocument=None, meeting=None,
-               masterFile=None, derivativeFile=None, license=None, fileRole=None, content=None, originalDownloadPossible = True):
-    self.body = body
-    self.originalId = originalId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.fileName = fileName
-    self.name = name
-    self.mimeType = mimeType
-    self.date = date
-    self.size = size
-    self.sha1Checksum = sha1Checksum
-    self.text = text
-    self.accessUrl = accessUrl
-    self.downloadUrl = downloadUrl
-    self.paper = paper #list generated(?)
-    self.meeting = meeting #list generated
-    self.masterFile = masterFile
-    self.derivativeFile = derivativeFile #list generated
-    self.license = license
-    self.fileRole = fileRole
-    
-    # Non OParl
-    self.x_content = content
-    self.originalDownloadPossible = originalDownloadPossible
-    
-    super(File, self).__init__()
+    """ A file class """
 
-  @property
-  def content(self):
-    return self.x_content
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, name=None,
+                 fileName=None, paper=None, mimeType=None, date=None,
+                 sha1Checksum=None, size=None, text=None, accessUrl=None,
+                 downloadUrl=None, masterDocument=None, meeting=None,
+                 masterFile=None, derivativeFile=None, license=None,
+                 fileRole=None, content=None, originalDownloadPossible=True):
+        self.body = body
+        self.originalId = originalId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
 
-  @content.setter
-  def content(self, value):
-    self.x_content = value
-    if value is None:
-      self.size = None
-      self.sha1Checksum = None
-    else:
-      self.size = len(value)
-      self.sha1Checksum = hashlib.sha1(value).hexdigest()
+        self.fileName = fileName
+        self.name = name
+        self.mimeType = mimeType
+        self.date = date
+        self.size = size
+        self.sha1Checksum = sha1Checksum
+        self.text = text
+        self.accessUrl = accessUrl
+        self.downloadUrl = downloadUrl
+        # list generated(?)
+        self.paper = paper
+        # list generated
+        self.meeting = meeting
+        self.masterFile = masterFile
+        # list generated
+        self.derivativeFile = derivativeFile
+        self.license = license
+        self.fileRole = fileRole
+
+        # Non OParl
+        self.x_content = content
+        self.originalDownloadPossible = originalDownloadPossible
+
+        super(File, self).__init__()
+
+    @property
+    def content(self):
+        return self.x_content
+
+    @content.setter
+    def content(self, value):
+        self.x_content = value
+        if value is None:
+            self.size = None
+            self.sha1Checksum = None
+        else:
+            self.size = len(value)
+            self.sha1Checksum = hashlib.sha1(value).hexdigest()

--- a/risscraper/model/filters.py
+++ b/risscraper/model/filters.py
@@ -4,50 +4,71 @@
 Copyright (c) 2012 - 2015, Marian Steinbach
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import parse
 import datetime
+
+import parse
 from pytz import timezone
 
 
 def remove_whitespace(string):
-  return string.replace(' ', '')
+    return string.replace(' ', '')
 
 
 def datestring_to_datetime(inp):
-  """
-  Convert a date/time string do proper start (and optionally end) datetime
-  """
-  berlin = timezone('Europe/Berlin')
-  if type(inp) in [str, unicode]:
-    string = inp.strip()
-    format = '{day:d}.{month:d}.{year:d} {hour:d}:{minute:d}-{hourend:d}:{minuteend:d}'
-    p = parse.parse(format, string)
-    if p is not None:
-      out = datetime.datetime(p['year'], p['month'], p['day'], p['hour'], p['minute'], tzinfo=berlin)
-      return out
-    else:
-      format = '{day:d}.{month:d}.{year:d} {hour:d}:{minute:d}'
-      p = parse.parse(format, string)
-      if p is not None:
-        out = datetime.datetime(p['year'], p['month'], p['day'], p['hour'], p['minute'], tzinfo=berlin)
-        return out
-      else:
-        format = '{day:d}.{month:d}.{year:d}'
-        p = parse.parse(format, string)
+    """ Convert a date/time string do proper start (and optionally end) datetime
+    """
+    berlin = timezone('Europe/Berlin')
+    if isinstance(inp, (str, unicode)):
+        string = inp.strip()
+        fmt = ('{day:d}.{month:d}.{year:d} '
+               '{hour:d}:{minute:d}-{hourend:d}:{minuteend:d}')
+        p = parse.parse(fmt, string)
         if p is not None:
-          out = datetime.datetime(p['year'], p['month'], p['day'], 0, 0, tzinfo=berlin)
-          return out
+            out = datetime.datetime(p['year'], p['month'], p['day'], p['hour'],
+                                    p['minute'], tzinfo=berlin)
+            return out
         else:
-          return None
-  return inp
+            fmt = '{day:d}.{month:d}.{year:d} {hour:d}:{minute:d}'
+            p = parse.parse(fmt, string)
+            if p is not None:
+                out = datetime.datetime(p['year'], p['month'], p['day'],
+                                        p['hour'], p['minute'], tzinfo=berlin)
+                return out
+            else:
+                fmt = '{day:d}.{month:d}.{year:d}'
+                p = parse.parse(fmt, string)
+                if p is not None:
+                    out = datetime.datetime(p['year'], p['month'], p['day'],
+                                            0, 0, tzinfo=berlin)
+                    return out
+                else:
+                    return None
+    return inp

--- a/risscraper/model/legislativeterm.py
+++ b/risscraper/model/legislativeterm.py
@@ -4,15 +4,32 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
@@ -20,52 +37,53 @@ import filters
 
 
 class LegislativeTerm(Base):
-  """
-  A legislativeterm class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               name=None, startDate=None, endDate=None):
-    self.body = body
-    self.originalId = originalId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.name = name
-    self.x_startDate = start
-    self.x_endDate = end
-    
-    super(LegislativeTerm, self).__init__()
-
-  @property
-  def startDate(self):
-    """Fancy getter for the x_date_start property"""
-    return self.x_startDate
-
-  @start.setter
-  def startDate(self, value):
     """
-    Fancy setter for the x_start property, which
-    applies a string-to-datetime filter if ecessary
+    A legislativeterm class
     """
-    if type(value) == str:
-      self.x_startDate = filters.datestring_to_datetime(value)
-    else:
-      self.x_startDate = value
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, name=None,
+                 startDate=None, endDate=None):
+        self.body = body
+        self.originalId = originalId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
 
-  @property
-  def endDate(self):
-    """Fancy getter for the x_end property"""
-    return self.x_endDate
+        self.name = name
+        self.x_startDate = startDate
+        self.x_endDate = endDate
 
-  @start.setter
-  def endDate(self, value):
-    """
-    Fancy setter for the x_end property, which
-    applies a string-to-datetime filter if ecessary
-    """
-    if type(value) == str:
-      self.x_endDate = filters.datestring_to_datetime(value)
-    else:
-      self.x_endDate = value
+        super(LegislativeTerm, self).__init__()
+
+    @property
+    def startDate(self):
+        """Fancy getter for the x_date_start property"""
+        return self.x_startDate
+
+    @start.setter
+    def startDate(self, value):
+        """
+        Fancy setter for the x_start property, which
+        applies a string-to-datetime filter if ecessary
+        """
+        if isinstance(value, str):
+            self.x_startDate = filters.datestring_to_datetime(value)
+        else:
+            self.x_startDate = value
+
+    @property
+    def endDate(self):
+        """Fancy getter for the x_end property"""
+        return self.x_endDate
+
+    @start.setter
+    def endDate(self, value):
+        """
+        Fancy setter for the x_end property, which
+        applies a string-to-datetime filter if ecessary
+        """
+        if isinstance(value, str):
+            self.x_endDate = filters.datestring_to_datetime(value)
+        else:
+            self.x_endDate = value

--- a/risscraper/model/location.py
+++ b/risscraper/model/location.py
@@ -4,43 +4,57 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
-import filters
 
 
 class Location(Base):
-  """
-  A location class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               description=None, room=None, streetAddress=None, postalCode=None,
-               locality=None, lat=None, lon=None):
-    self.body = body
-    self.originalId = originalId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.description = description
-    self.geometry = geometry
-    
-    #self.room = room
-    #self.streetAddress = streetAddress
-    #self.postalCode = postalCode
-    #self.locality = locality
-    
-    super(Location, self).__init__()
+    """ A location class """
 
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, description=None,
+                 room=None, streetAddress=None, postalCode=None, locality=None,
+                 lat=None, lon=None):
+        self.body = body
+        self.originalId = originalId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
 
+        self.description = description
+        self.geometry = geometry
+
+        #self.room = room
+        #self.streetAddress = streetAddress
+        #self.postalCode = postalCode
+        #self.locality = locality
+
+        super(Location, self).__init__()

--- a/risscraper/model/meeting.py
+++ b/risscraper/model/meeting.py
@@ -4,15 +4,32 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
@@ -20,72 +37,86 @@ import filters
 
 
 class Meeting(Base):
-  """
-  A meeting class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               name=None, shortName=None, start=None, end=None, room=None, streetAdress=None, postalCode=None, locality=None, type=None, location=None,
-               organization=None, chairPerson=None, scribe=None, participant=None, invited=None, attendant=None,
-               invitation=None, resultsProtocol=None, verbatimProtocol=None, auxiliaryFile=None, agendaItem=None, nameShort=None):
-    self.originalId = originalId
-    self.body = body
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.name = name
-    self.x_start = start
-    self.x_end = end
-    self.room = room
-    self.streetAddress = streetAdress
-    self.postalCode = postalCode
-    self.locality = locality
-    self.type = type # non-oparl
-    self.location = location # ref
-    self.organization = organization # list of organization
-    self.chairPerson = chairPerson
-    self.participant = participant # ref list depreciated(?)
-    self.invitation = invitation #list of file
-    self.scribe = scribe
-    self.invited = invited #list
-    self.attendant = attendant #list
-    
-    self.resultsProtocol = resultsProtocol #file
-    self.verbatimProtocol = verbatimProtocol #file
-    self.auxiliaryFile = auxiliaryFile #list of file
-    self.agendaItem = agendaItem #list of agendaitem
-    
-    super(Meeting, self).__init__()
+    """ A meeting class """
 
-  @property
-  def start(self):
-    """Fancy getter for the x_date_start property"""
-    return self.x_start
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, name=None,
+                 shortName=None, start=None, end=None, room=None,
+                 streetAdress=None, postalCode=None, locality=None, type=None,
+                 location=None, organization=None, chairPerson=None,
+                 scribe=None, participant=None, invited=None, attendant=None,
+                 invitation=None, resultsProtocol=None, verbatimProtocol=None,
+                 auxiliaryFile=None, agendaItem=None, nameShort=None):
+        self.originalId = originalId
+        self.body = body
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
 
-  @start.setter
-  def start(self, value):
-    """
-    Fancy setter for the x_start property, which
-    applies a string-to-datetime filter if ecessary
-    """
-    if type(value) == str:
-      self.x_start = filters.datestring_to_datetime(value)
-    else:
-      self.x_start = value
+        self.name = name
+        self.x_start = start
+        self.x_end = end
+        self.room = room
+        self.streetAddress = streetAdress
+        self.postalCode = postalCode
+        self.locality = locality
+        # non-oparl
+        self.type = type
+        # ref
+        self.location = location
+        # list of organization
+        self.organization = organization
+        self.chairPerson = chairPerson
+        # ref list depreciated(?)
+        self.participant = participant
+        # list of file
+        self.invitation = invitation
+        self.scribe = scribe
+        # list
+        self.invited = invited
+        # list
+        self.attendant = attendant
 
-  @property
-  def end(self):
-    """Fancy getter for the x_end property"""
-    return self.x_end
+        # file
+        self.resultsProtocol = resultsProtocol
+        # file
+        self.verbatimProtocol = verbatimProtocol
+        # list of file
+        self.auxiliaryFile = auxiliaryFile
+        # list of agendaitem
+        self.agendaItem = agendaItem
 
-  @start.setter
-  def end(self, value):
-    """
-    Fancy setter for the x_end property, which
-    applies a string-to-datetime filter if ecessary
-    """
-    if type(value) == str:
-      self.x_end = filters.datestring_to_datetime(value)
-    else:
-      self.x_end = value
+        super(Meeting, self).__init__()
+
+    @property
+    def start(self):
+        """Fancy getter for the x_date_start property"""
+        return self.x_start
+
+    @start.setter
+    def start(self, value):
+        """
+        Fancy setter for the x_start property, which
+        applies a string-to-datetime filter if ecessary
+        """
+        if isinstance(value, str):
+            self.x_start = filters.datestring_to_datetime(value)
+        else:
+            self.x_start = value
+
+    @property
+    def end(self):
+        """Fancy getter for the x_end property"""
+        return self.x_end
+
+    @end.setter
+    def end(self, value):
+        """
+        Fancy setter for the x_end property, which
+        applies a string-to-datetime filter if ecessary
+        """
+        if isinstance(value, str):
+            self.x_end = filters.datestring_to_datetime(value)
+        else:
+            self.x_end = value

--- a/risscraper/model/membership.py
+++ b/risscraper/model/membership.py
@@ -4,15 +4,32 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
@@ -20,58 +37,58 @@ import filters
 
 
 class Membership(Base):
-  """
-  A membership class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               person=None, organization=None, role=None, post=None, onBehalfOf=None, startDate=None, endDate=None):
-    self.originalId = originalId
-    self.body = body
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.person = person
-    self.organization = organization
-    self.role = role
-    self.post = post
-    self.onBehalfOf = onBehalfOf
-    self.x_startDate = startDate
-    self.x_endDate = endDate
-    
-    super(Membership, self).__init__()
-
-
-  @property
-  def startDate(self):
-    """Fancy getter for the date property"""
-    return self.x_startDate
-
-  @startDate.setter
-  def startDate(self, value):
     """
-    Fancy setter for the x_date property, which
-    applies a string-to-datetime filter if necessary
+    A membership class
     """
-    if type(value) == str:
-      self.x_startDate = filters.datestring_to_datetime(value)
-    else:
-      self.x_startDate = value
-      
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, person=None,
+                 organization=None, role=None, post=None, onBehalfOf=None,
+                 startDate=None, endDate=None):
+        self.originalId = originalId
+        self.body = body
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
 
-  @property
-  def endDate(self):
-    """Fancy getter for the date property"""
-    return self.x_endDate
+        self.person = person
+        self.organization = organization
+        self.role = role
+        self.post = post
+        self.onBehalfOf = onBehalfOf
+        self.x_startDate = startDate
+        self.x_endDate = endDate
 
-  @endDate.setter
-  def endDate(self, value):
-    """
-    Fancy setter for the x_date property, which
-    applies a string-to-datetime filter if necessary
-    """
-    if type(value) == str:
-      self.x_endDate = filters.datestring_to_datetime(value)
-    else:
-      self.x_endDate = value
+        super(Membership, self).__init__()
+
+    @property
+    def startDate(self):
+        """Fancy getter for the date property"""
+        return self.x_startDate
+
+    @startDate.setter
+    def startDate(self, value):
+        """
+        Fancy setter for the x_date property, which
+        applies a string-to-datetime filter if necessary
+        """
+        if isinstance(value, str):
+            self.x_startDate = filters.datestring_to_datetime(value)
+        else:
+            self.x_startDate = value
+
+    @property
+    def endDate(self):
+        """Fancy getter for the date property"""
+        return self.x_endDate
+
+    @endDate.setter
+    def endDate(self, value):
+        """
+        Fancy setter for the x_date property, which
+        applies a string-to-datetime filter if necessary
+        """
+        if isinstance(value, str):
+            self.x_endDate = filters.datestring_to_datetime(value)
+        else:
+            self.x_endDate = value

--- a/risscraper/model/organization.py
+++ b/risscraper/model/organization.py
@@ -4,42 +4,63 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
-import filters
 
 
 class Organization(Base):
-  """
-  A organisation class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               name=None, shortName=None, post=None, meeting=None, membership=None,
-               classification=None, subOrganizationOf=None, startDate=None, endDate=None):
-    self.originalId = originalId
-    self.body = body
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword #list
-    
-    self.name = name
-    self.shortName = shortName
-    self.post = post #list
-    self.meeting = meeting #list generated
-    self.membership = membership #list
-    self.classification = classification
-    self.subOrganizationOf = subOrganizationOf
-    self.startDate = startDate
-    self.endDate = endDate
-    super(Organization, self).__init__()
+    """ An organisation class """
+
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, name=None,
+                 shortName=None, post=None, meeting=None, membership=None,
+                 classification=None, subOrganizationOf=None, startDate=None,
+                 endDate=None):
+        self.originalId = originalId
+        self.body = body
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        # list
+        self.keyword = keyword
+
+        self.name = name
+        self.shortName = shortName
+        # list
+        self.post = post
+        # list generated
+        self.meeting = meeting
+        # list
+        self.membership = membership
+        self.classification = classification
+        self.subOrganizationOf = subOrganizationOf
+        self.startDate = startDate
+        self.endDate = endDate
+        super(Organization, self).__init__()

--- a/risscraper/model/paper.py
+++ b/risscraper/model/paper.py
@@ -4,15 +4,32 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
@@ -20,52 +37,59 @@ import filters
 
 
 class Paper(Base):
-  """
-  A paper class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-               name=None, nameShort=None, reference=None, publishedDate=None, paperType=None, relatedPaper=None,
-               mainFile=None, auxiliaryFile=None, location=None, originator=None, consultation=None, underDirectionOf=None,
-               superordinatedPaper=None, subordinatedPaper=None):
-    self.body = body
-    self.originalId = originalId
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.name = name
-    self.nameShort = nameShort
-    self.reference = reference
-    self.x_publishedDate = publishedDate
-    self.paperType = paperType
-    self.relatedPaper = relatedPaper #list of paper
-    self.mainFile = mainFile
-    self.auxiliaryFile = auxiliaryFile #list of file
-    self.location = location #list
-    self.originator = originator #list of person or organization
-    self.consultation = consultation #list of consultation
-    self.underDirectionOf = underDirectionOf #list of organization
-    
-    # Non OParl
-    self.superordinatedPaper = superordinatedPaper
-    self.subordinatedPaper = subordinatedPaper
-    
-    super(Paper, self).__init__()
+    """ A paper class """
 
-  @property
-  def publishedDate(self):
-    """Fancy getter for the date property"""
-    return self.x_publishedDate
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, name=None,
+                 nameShort=None, reference=None, publishedDate=None,
+                 paperType=None, relatedPaper=None, mainFile=None,
+                 auxiliaryFile=None, location=None, originator=None,
+                 consultation=None, underDirectionOf=None,
+                 superordinatedPaper=None, subordinatedPaper=None):
+        self.body = body
+        self.originalId = originalId
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
 
-  @publishedDate.setter
-  def publishedDate(self, value):
-    """
-    Fancy setter for the x_date property, which
-    applies a string-to-datetime filter if necessary
-    """
-    if type(value) == str:
-      self.x_publishedDate = filters.datestring_to_datetime(value)
-    else:
-      self.x_publishedDate = value
+        self.name = name
+        self.nameShort = nameShort
+        self.reference = reference
+        self.x_publishedDate = publishedDate
+        self.paperType = paperType
+        # list of paper
+        self.relatedPaper = relatedPaper
+        self.mainFile = mainFile
+        # list of file
+        self.auxiliaryFile = auxiliaryFile
+        # list
+        self.location = location
+        # list of person or organization
+        self.originator = originator
+        # list of consultation
+        self.consultation = consultation
+        # list of organization
+        self.underDirectionOf = underDirectionOf
 
+        # Non OParl
+        self.superordinatedPaper = superordinatedPaper
+        self.subordinatedPaper = subordinatedPaper
+
+        super(Paper, self).__init__()
+
+    @property
+    def publishedDate(self):
+        """Fancy getter for the date property"""
+        return self.x_publishedDate
+
+    @publishedDate.setter
+    def publishedDate(self, value):
+        """
+        Fancy setter for the x_date property, which
+        applies a string-to-datetime filter if necessary
+        """
+        if isinstance(value, str):
+            self.x_publishedDate = filters.datestring_to_datetime(value)
+        else:
+            self.x_publishedDate = value

--- a/risscraper/model/person.py
+++ b/risscraper/model/person.py
@@ -4,52 +4,72 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from base import Base
-import filters
 
 
 class Person(Base):
-  """
-  A person class
-  """
-  def __init__(self, originalId=None, body=None, originalUrl=None, created=None, modified=None, keyword=None,
-      name=None, familyName=None, givenName=None, title=None, formOfAddress=None, gender=None,
-      email=None, phone=None, streetAddress=None, postalCode=None, locality=None, status=None, membership=None,
-      fax=None, mobile=None, website=None):
-    self.originalId = originalId
-    self.body = body
-    self.originalUrl = originalUrl
-    self.created = created
-    self.modified = modified
-    self.keyword = keyword
-    
-    self.name = name
-    self.familyName = familyName
-    self.givenName = givenName
-    self.title = title #list
-    self.formOfAddress = formOfAddress
-    self.gender = gender
-    self.email = email
-    self.phone = phone
-    self.streetAddress = streetAddress
-    self.postalCode = postalCode
-    self.locality = locality
-    self.status = status
-    self.membership = membership #list
-    
-    # non OParl
-    self.fax = fax
-    self.mobile = mobile
-    self.website = website
-    super(Person, self).__init__()
+    """ A person class """
+
+    def __init__(self, originalId=None, body=None, originalUrl=None,
+                 created=None, modified=None, keyword=None, name=None,
+                 familyName=None, givenName=None, title=None,
+                 formOfAddress=None, gender=None, email=None, phone=None,
+                 streetAddress=None, postalCode=None, locality=None,
+                 status=None, membership=None, fax=None, mobile=None,
+                 website=None):
+        self.originalId = originalId
+        self.body = body
+        self.originalUrl = originalUrl
+        self.created = created
+        self.modified = modified
+        self.keyword = keyword
+
+        self.name = name
+        self.familyName = familyName
+        self.givenName = givenName
+        # list
+        self.title = title
+        self.formOfAddress = formOfAddress
+        self.gender = gender
+        self.email = email
+        self.phone = phone
+        self.streetAddress = streetAddress
+        self.postalCode = postalCode
+        self.locality = locality
+        self.status = status
+        # list
+        self.membership = membership
+
+        # non OParl
+        self.fax = fax
+        self.mobile = mobile
+        self.website = website
+        super(Person, self).__init__()

--- a/risscraper/queue.py
+++ b/risscraper/queue.py
@@ -4,198 +4,213 @@
 Copyright (c) 2012 - 2015, Marian Steinbach
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from pymongo import MongoClient
-from pymongo.errors import DuplicateKeyError
 from datetime import datetime
+
+from pymongo.errors import DuplicateKeyError
 
 
 class Queue(object):
-  """Abstrakte Warteschlange, die zum Abarbeiten von Sitzungen,
-  Dokumenten etc. benutzt wird. Bereits verarbeitete Elemente
-  werden weiterhin gespeichert und können nicht erneut hinzugefügt
-  werden."""
+    """Abstrakte Warteschlange, die zum Abarbeiten von Sitzungen,
+    Dokumenten etc. benutzt wird. Bereits verarbeitete Elemente
+    werden weiterhin gespeichert und können nicht erneut hinzugefügt
+    werden."""
 
-  def __init__(self, name, config, db):
-    self.name = name
-    self.config = config
-    self.db = db.db
-    self.db.queue.ensure_index([('rs', 1), ('qname', 1), ('key', 1)], unique=True)
+    def __init__(self, name, config, db):
+        self.name = name
+        self.config = config
+        self.db = db.db
+        self.db.queue.ensure_index([('rs', 1), ('qname', 1), ('key', 1)], unique=True)
 
-  def has_next(self):
-    """Gibt True zurück, wenn Elemente in der Warteschlange sind."""
-    if len(self) > 0:
-      return True
-    return False
+    def has_next(self):
+        """Gibt True zurück, wenn Elemente in der Warteschlange sind."""
+        if len(self) > 0:
+            return True
+        return False
 
-  def add(self, key_or_element):
-    """Fügt ein Element zur Warteschlange hinzu. Wenn das Element schon
-    in der Warteschlange ist, wird es nicht noch mal hinzugefügt, jedoch
-    kein Fehler erzeugt. Sollte das Element schon mal hinzugefügt und
-    bereits verarbeitet worden sein, wird ebenfalls kein Fehler erzeugt.
+    def add(self, key_or_element):
+        """Fügt ein Element zur Warteschlange hinzu. Wenn das Element schon
+        in der Warteschlange ist, wird es nicht noch mal hinzugefügt, jedoch
+        kein Fehler erzeugt. Sollte das Element schon mal hinzugefügt und
+        bereits verarbeitet worden sein, wird ebenfalls kein Fehler erzeugt.
 
-    Das Element muss ein dict mit den Eigenschaften 'key' (Pflicht) und
-    optional 'payload' sein."""
-    key = None
-    payload = None
-    if type(key_or_element) == dict:
-      key = key_or_element['key']
-      if 'payload' in key_or_element:
-        payload = key_or_element['payload']
-    else:
-      key = key_or_element
-    job = {
-      'body_uid': self.config['city']['_id'],
-      'qname': self.name,
-      'status': 'OPEN',
-      'key': key,
-      'failures': 0,
-      'modified': datetime.utcnow()
-    }
-    if payload is not None:
-      job['payload'] = payload
-    try:
-      self.db.queue.save(job)
-    except DuplicateKeyError:
-      pass
+        Das Element muss ein dict mit den Eigenschaften 'key' (Pflicht) und
+        optional 'payload' sein."""
+        key = None
+        payload = None
+        if isinstance(key_or_element, dict):
+            key = key_or_element['key']
+            if 'payload' in key_or_element:
+                payload = key_or_element['payload']
+        else:
+            key = key_or_element
+        job = {
+            'body_uid': self.config['city']['_id'],
+            'qname': self.name,
+            'status': 'OPEN',
+            'key': key,
+            'failures': 0,
+            'modified': datetime.utcnow()
+        }
+        if payload is not None:
+            job['payload'] = payload
+        try:
+            self.db.queue.save(job)
+        except DuplicateKeyError:
+            pass
 
-  def get(self):
-    """Gibt ein Element aus der Warteschlange zurück und markiert es
-    als "IN_PROGRESS". Wenn kein Element mehr vorhanden ist, wird
-    ein KeyError geworfen."""
-    # BTW: we don't care for the sort order right now.
-    query = {
-      'body_uid': self.config['city']['_id'],
-      'qname': self.name,
-      'status': 'OPEN'
-    }
-    update = {
-      '$set': {
-        'status': 'IN_PROGRESS',
-        'modified': datetime.utcnow()
-      }
-    }
-    find = self.db.queue.find_and_modify(query=query,
-      update=update)
-    out = {'key': find['key']}
-    if 'payload' in find:
-      out['payload'] = find['payload']
-    return out
+    def get(self):
+        """Gibt ein Element aus der Warteschlange zurück und markiert es
+        als "IN_PROGRESS". Wenn kein Element mehr vorhanden ist, wird
+        ein KeyError geworfen."""
+        # BTW: we don't care for the sort order right now.
+        query = {
+            'body_uid': self.config['city']['_id'],
+            'qname': self.name,
+            'status': 'OPEN'
+        }
+        update = {
+            '$set': {
+                'status': 'IN_PROGRESS',
+                'modified': datetime.utcnow()
+            }
+        }
+        find = self.db.queue.find_and_modify(query=query, update=update)
+        out = {'key': find['key']}
+        if 'payload' in find:
+            out['payload'] = find['payload']
+        return out
 
-  def __len__(self):
-    """
-    Returns the number of OPEN jobs
-    """
-    query = {
-      'body_uid': self.config['city']['_id'],
-      'qname': self.name,
-      'status': 'OPEN'
-    }
-    num = self.db.queue.find(query).count()
-    return num
+    def __len__(self):
+        """
+        Returns the number of OPEN jobs
+        """
+        query = {
+            'body_uid': self.config['city']['_id'],
+            'qname': self.name,
+            'status': 'OPEN'
+        }
+        num = self.db.queue.find(query).count()
+        return num
 
-  def resolve_job(self, key_or_element):
-    """
-    Mark a job as "DONE". The job can be either indicated
-    by a dict with a "key" element or a key int/string directly
-    """
-    key = None
-    if type(key_or_element) == dict:
-      key = key_or_element['key']
-    else:
-      key = key_or_element
-    query = {
-      'body_uid': self.config['city']['_id'],
-      'qname': self.name,
-      'key': key
-    }
-    update = {
-      '$set': {
-        'status': 'DONE',
-        'modified': datetime.utcnow()
-      }
-    }
-    self.db.queue.find_and_modify(query=query,
-      update=update)
+    def resolve_job(self, key_or_element):
+        """
+        Mark a job as "DONE". The job can be either indicated
+        by a dict with a "key" element or a key int/string directly
+        """
+        key = None
+        if isinstance(key_or_element, dict):
+            key = key_or_element['key']
+        else:
+            key = key_or_element
+        query = {
+            'body_uid': self.config['city']['_id'],
+            'qname': self.name,
+            'key': key
+        }
+        update = {
+            '$set': {
+                'status': 'DONE',
+                'modified': datetime.utcnow()
+            }
+        }
+        self.db.queue.find_and_modify(query=query, update=update)
 
-  def mark_failed(self, key_or_element):
-    """
-    Add 1 to the failure count of a job.
-    If the failure count reaches 3, set the job status
-    to "FAILED".
-    """
-    key = None
-    if type(key_or_element) == dict:
-      key = key_or_element['key']
-    else:
-      key = key_or_element
-    query = {
-      'body_uid': self.config['city']['_id'],
-      'qname': self.name,
-      'key': key
-    }
-    job = self.db.queue.find_one(query)
-    update = {
-      '$inc': {
-        'failures': 1
-      }
-    }
-    if job['failures'] >= 2:
-      update['$set'] = {
-        'status': 'FAILED'
-      }
-    self.db.queue.update(
-      {'_id': job['_id']},
-      update)
+    def mark_failed(self, key_or_element):
+        """
+        Add 1 to the failure count of a job.
+        If the failure count reaches 3, set the job status
+        to "FAILED".
+        """
+        key = None
+        if isinstance(key_or_element, dict):
+            key = key_or_element['key']
+        else:
+            key = key_or_element
+        query = {
+            'body_uid': self.config['city']['_id'],
+            'qname': self.name,
+            'key': key
+        }
+        job = self.db.queue.find_one(query)
+        update = {
+            '$inc': {
+                'failures': 1
+            }
+        }
+        if job['failures'] >= 2:
+            update['$set'] = {
+                'status': 'FAILED'
+            }
+        self.db.queue.update(
+            {'_id': job['_id']},
+            update)
 
-  def garbage_collect(self):
-    """
-    Remove all DONE elements from queue
-    """
-    query = {
-      'body_uid': self.config['city']['_id'],
-      'qname': self.name,
-      'status': 'DONE'
-    }
-    self.db.queue.remove(query)
+    def garbage_collect(self):
+        """
+        Remove all DONE elements from queue
+        """
+        query = {
+            'body_uid': self.config['city']['_id'],
+            'qname': self.name,
+            'status': 'DONE'
+        }
+        self.db.queue.remove(query)
 
 
 """ Zeugs
 if __name__ == '__main__':
-  connection = MongoClient()
-  db = connection.test
-  class cfg(object):
-    RS = "foobar"
-  config = cfg
-  q = Queue('TEST_QUEUE', config, db)
-  assert q.has_next() == False
-  q.add({'key': 1})
-  assert q.has_next() == True
-  q.add({'key': 1})
-  q.add({'key': 2})
-  q.add({'key': 3})
-  assert len(q) == 3
-  job1 = q.get()
-  assert len(q) == 2
-  job2 = q.get()
-  assert len(q) == 1
-  job3 = q.get()
-  assert len(q) == 0
-  assert q.has_next() == False
-  q.resolve_job(job1)
-  q.resolve_job(job2)
-  q.mark_failed(job3)
-  q.mark_failed(job3)
-  q.mark_failed(job3)
-  q.garbage_collect()
+    connection = MongoClient()
+    db = connection.test
+    class cfg(object):
+        RS = "foobar"
+    config = cfg
+    q = Queue('TEST_QUEUE', config, db)
+    assert q.has_next() == False
+    q.add({'key': 1})
+    assert q.has_next() == True
+    q.add({'key': 1})
+    q.add({'key': 2})
+    q.add({'key': 3})
+    assert len(q) == 3
+    job1 = q.get()
+    assert len(q) == 2
+    job2 = q.get()
+    assert len(q) == 1
+    job3 = q.get()
+    assert len(q) == 0
+    assert q.has_next() == False
+    q.resolve_job(job1)
+    q.resolve_job(job2)
+    q.mark_failed(job3)
+    q.mark_failed(job3)
+    q.mark_failed(job3)
+    q.garbage_collect()
 """

--- a/risscraper/scraperallris.py
+++ b/risscraper/scraperallris.py
@@ -4,38 +4,48 @@
 Copyright (c) 2012 - 2015, Ernesto Ruge, Christian Scholz
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import mechanize
-import urllib2
-import parse
 import datetime
-import time
-import queue
+import HTMLParser
+import logging
+import re
 import sys
+import time
+
 from lxml import etree, html
 from lxml.cssselect import CSSSelector
-from StringIO import StringIO
-import hashlib
 import magic
-import os
-import logging
-import requests
-import pytz
-import re
+import mechanize
 from pytz import timezone
-import HTMLParser
+import requests
 
-from model.body import Body
 from model.person import Person
 from model.membership import Membership
 from model.organization import Organization
@@ -44,732 +54,896 @@ from model.consultation import Consultation
 from model.paper import Paper
 from model.agendaitem import AgendaItem
 from model.file import File
+import queue
+
 
 class ScraperAllRis(object):
-  
-  body_re = re.compile("<?xml .*<body[ ]*>(.*)</body>") # find everything inside a body of a subdocument
-  TIME_MARKER = datetime.datetime(1903,1,1) # marker for no date being found
-  
-  #adoption_css = CSSSelector("#rismain table.risdeco tbody tr td table.tk1 tbody tr td table.tk1 tbody tr td table tbody tr.zl12 td.text3")
-  #adoption_css = CSSSelector("table.risdeco tr td table.tk1 tr td.ko1 table.tk1 tr td table tr.zl12 td.text3")
-  adoption_css = CSSSelector("tr.zl12:nth-child(3) > td:nth-child(5)") # selects the td which holds status information such as "beschlossen"
-  top_css = CSSSelector("tr.zl12:nth-child(3) > td:nth-child(7) > form:nth-child(1) > input:nth-child(1)") # selects the td which holds the link to the TOP with transcript
-  table_css = CSSSelector(".ko1 > table:nth-child(1)") # table with info block
-  attachment_1_css = CSSSelector('input[name=DOLFDNR]')
-  attachments_css = CSSSelector('table.risdeco table.tk1 table.tk1 table.tk1')
-  #main_css = CSSSelector("#rismain table.risdeco")
+
+    # find everything inside a body of a subdocument
+    body_re = re.compile("<?xml .*<body[ ]*>(.*)</body>")
+    # marker for no date being found
+    TIME_MARKER = datetime.datetime(1903, 1, 1)
+
+    """
+    adoption_css = CSSSelector("#rismain table.risdeco tbody tr td table.tk1 "
+                               "tbody tr td table.tk1 tbody tr td table tbody "
+                               "tr.zl12 td.text3")
+    adoption_css = CSSSelector("table.risdeco tr td table.tk1 tr td.ko1 "
+                               "table.tk1 tr td table tr.zl12 td.text3")
+    """
+    # selects the td which holds status information such as "beschlossen"
+    adoption_css = CSSSelector("tr.zl12:nth-child(3) > td:nth-child(5)")
+    # selects the td which holds the link to the TOP with transcript
+    top_css = CSSSelector("tr.zl12:nth-child(3) > td:nth-child(7) > "
+                          "form:nth-child(1) > input:nth-child(1)")
+    # table with info block
+    table_css = CSSSelector(".ko1 > table:nth-child(1)")
+    attachment_1_css = CSSSelector('input[name=DOLFDNR]')
+    attachments_css = CSSSelector('table.risdeco table.tk1 table.tk1 table.tk1')
+    #main_css = CSSSelector("#rismain table.risdeco")
 
 
-  def __init__(self, config, db, options):
-    # configuration
-    self.config = config
-    # command line options and defaults
-    self.options = options
-    # database object
-    self.db = db
-    # mechanize user agent
-    self.user_agent = mechanize.Browser()
-    self.user_agent.set_handle_robots(False)
-    self.user_agent.addheaders = [('User-agent', config['scraper']['user_agent_name'])]
-    # Queues
-    if self.options.workfromqueue:
-      self.person_queue = queue.Queue('ALLRIS_PERSON', config, db)
-      self.meeting_queue = queue.Queue('ALLRIS_MEETING', config, db)
-      self.paper_queue = queue.Queue('ALLRIS_PAPER', config, db)
-    # system info (PHP/ASP)
-    self.template_system = None
-    self.urls = None
-    self.xpath = None
-    
-    self.user_agent = mechanize.Browser()
-    self.user_agent.set_handle_robots(False)
-    self.user_agent.addheaders = [('User-agent', config['scraper']['user_agent_name'])]
+    def __init__(self, config, db, options):
+        # configuration
+        self.config = config
+        # command line options and defaults
+        self.options = options
+        # database object
+        self.db = db
+        # mechanize user agent
+        self.user_agent = mechanize.Browser()
+        self.user_agent.set_handle_robots(False)
+        self.user_agent.addheaders = [('User-agent', config['scraper']['user_agent_name'])]
+        # Queues
+        if self.options.workfromqueue:
+            self.person_queue = queue.Queue('ALLRIS_PERSON', config, db)
+            self.meeting_queue = queue.Queue('ALLRIS_MEETING', config, db)
+            self.paper_queue = queue.Queue('ALLRIS_PAPER', config, db)
+        # system info (PHP/ASP)
+        self.template_system = None
+        self.urls = None
+        self.xpath = None
 
-  def work_from_queue(self):
-    """
-    Empty queues if they have values. Queues are emptied in the
-    following order:
-    1. Person
-    2. Meeting
-    3. Paper
-    """
-    while self.person_queue.has_next():
-      job = self.person_queue.get()
-      self.get_person(person_id=job['key'])
-      self.get_person_organization(person_id=job['key'])
-      self.person_queue.resolve_job(job)
-    while self.meeting_queue.has_next():
-      job = self.meeting_queue.get()
-      self.get_meeting(meeting_id=job['key'])
-      self.meeting_queue.resolve_job(job)
-    while self.paper_queue.has_next():
-      job = self.paper_queue.get()
-      self.get_paper(paper_id=job['key'])
-      self.paper_queue.resolve_job(job)
-    # when everything is done, we remove DONE jobs
-    self.person_queue.garbage_collect()
-    self.meeting_queue.garbage_collect()
-    self.paper_queue.garbage_collect()
+        self.user_agent = mechanize.Browser()
+        self.user_agent.set_handle_robots(False)
+        self.user_agent.addheaders = [('User-agent', config['scraper']['user_agent_name'])]
 
-  def guess_system(self):
-    """
-    Tries to find out which AllRis version we are working with
-    and adapts configuration
-    TODO: XML Guess
-    """
-    self.template_system = 'xml'
-    logging.info("Nothing to guess until now.")
+    def work_from_queue(self):
+        """
+        Empty queues if they have values. Queues are emptied in the
+        following order:
+        1. Person
+        2. Meeting
+        3. Paper
+        """
+        while self.person_queue.has_next():
+            job = self.person_queue.get()
+            self.get_person(person_id=job['key'])
+            self.get_person_organization(person_id=job['key'])
+            self.person_queue.resolve_job(job)
+        while self.meeting_queue.has_next():
+            job = self.meeting_queue.get()
+            self.get_meeting(meeting_id=job['key'])
+            self.meeting_queue.resolve_job(job)
+        while self.paper_queue.has_next():
+            job = self.paper_queue.get()
+            self.get_paper(paper_id=job['key'])
+            self.paper_queue.resolve_job(job)
+        # when everything is done, we remove DONE jobs
+        self.person_queue.garbage_collect()
+        self.meeting_queue.garbage_collect()
+        self.paper_queue.garbage_collect()
 
-  def find_person(self):
-    find_person_url = self.config['scraper']['base_url'] + 'kp041.asp?template=xyz&selfaction=ws&showAll=true&PALFDNRM=1&kpdatfil=&filtdatum=filter&kpname=&kpsonst=&kpampa=99999999&kpfr=99999999&kpamfr=99999999&kpau=99999999&kpamau=99999999&searchForm=true&search=Suchen'
-    logging.info("Getting person overview from %s" % (find_person_url))
-    
-    """parse an XML file and return the tree"""
-    parser = etree.XMLParser(recover=True)
-    r = self.get_url(find_person_url)
-    if not r:
-      return
-    xml = r.text.encode('ascii','xmlcharrefreplace') 
-    tree = etree.fromstring(xml, parser=parser)
-    h = HTMLParser.HTMLParser()
-  
-    # element 0 is the special block
-    # element 1 is the list of persons
-    for node in tree[1].iterchildren():
-      elem = {}
-      for e in node.iterchildren():
-        if e.text:
-          elem[e.tag] = h.unescape(e.text)
-        else:
-          elem[e.tag] = ''
-      
-      # now retrieve person details such as organization memberships etc.
-      # we also get the age (but only that, no date of birth)
-      person = Person(originalId=int(elem['kplfdnr']))
-      if elem['link_kp']:
-        person.originalUrl = elem['link_kp']
-      # personal information
-      
-      if elem['adtit']:
-        person.title = elem['adtit']
-      if elem['antext1'] == 'Frau':
-        person.sex = 1
-      elif elem['antext1'] == 'Herr':
-        person.sex = 2
-      if elem['advname']:
-        person.firstname = elem['advname']
-      if elem['adname']:
-        person.lastname = elem['adname']
-      
-      # address
-      if elem['adstr']:
-        person.address = elem['adstr']
-      if elem['adhnr']:
-        person.house_number = elem['adhnr']
-      if elem['adplz']:
-        person.postalcode = elem['adplz']
-      if elem['adtel']:
-        person.phone = elem['adtel']
-      
-      # contact
-      if elem['adtel']:
-        person.phone = elem['adtel']
-      if elem['adtel2']:
-        person.mobile = elem['adtel2']
-      if elem['adfax']:
-        person.fax = elem['adfax']
-      if elem['adfax']:
-        person.fax = elem['adfax']
-      if elem['ademail']:
-        person.email = elem['ademail']
-      if elem['adwww1']:
-        person.website = elem['adwww1']
-      
-      person_party = elem['kppartei']
-      if person_party:
-        if person_party in self.config['scraper']['party_alias']:
-          person_party = self.config['scraper']['party_alias'][person_party]
-        new_organization = Organization(originalId=person_party, name=person_party, classification='party')
-        person.membership = [Membership(originalId=unicode(person.originalId) + '-' + person_party, organization=new_organization)]
-      
-      if elem['link_kp'] is not None:
-        if hasattr(self, 'person_queue'):
-          self.person_queue.add(person.originalId)
-      else:
-        logging.info("Person %s %s has no link", person.firstname, person.lastname)
-      oid = self.db.save_person(person)
-        
-  
-  def find_meeting(self, start_date=None, end_date=None):
-    """
-    Find meetings within a given time frame and add them to the meeting queue.
-    """
-    meeting_find_url = self.config['scraper']['allris']['meeting_find_url'] % (self.config['scraper']['base_url'], start_date.strftime("%d.%m.%Y"), end_date.strftime("%d.%m.%Y"))
-    logging.info("Getting meeting overview from %s", meeting_find_url)
-    
-    parser = etree.XMLParser(recover=True)
-    h = HTMLParser.HTMLParser()
-    
-    r = self.get_url(meeting_find_url)
-    if not r:
-      return
-    
-    xml = r.text.encode('ascii','xmlcharrefreplace').replace('</a>', '')
-    xml = re.sub(r'<a href="([^"]*)" target="_blank" ?>', r'\1', xml)
-    root = etree.fromstring(xml, parser=parser)
-    for item in root:
-      if item.tag == 'list':
-        root = item
-        break
-    for item in root.iterchildren():
-      raw_meeting = {}
-      for e in item.iterchildren():
-        if e.text:
-          raw_meeting[e.tag] = h.unescape(e.text)
-        else:
-          raw_meeting[e.tag] = ''
-      meeting = Meeting(originalId=int(raw_meeting['silfdnr']))
-      meeting.start = self.parse_date(raw_meeting['sisbvcs'])
-      meeting.end = self.parse_date(raw_meeting['sisevcs'])
-      meeting.name = raw_meeting['siname']
-      meeting.originalUrl = "%sto010.asp?SILFDNR=%s&options=4" % (self.config['scraper']['base_url'], raw_meeting['silfdnr'])
-      meeting.name = raw_meeting['sitext']
-      meeting.organization_name = raw_meeting['grname']
-      # meeting.description = raw_meeting['sitext'] # WHAT TO DO WITH THIS
-      oid = self.db.save_meeting(meeting)
-      self.meeting_queue.add(meeting.originalId)
-      
+    def guess_system(self):
+        """
+        Tries to find out which AllRis version we are working with
+        and adapts configuration
+        TODO: XML Guess
+        """
+        self.template_system = 'xml'
+        logging.info("Nothing to guess until now.")
 
-  def get_organization(self, organization_id=None, organization_url=None):
-    pass
-  
-  def get_person(self, person_id=None, person_url=None):
-    # we dont need this(?)
-    pass
-  
-  def get_person_organization(self, person_id=None, organization_url=None):
-    url = "%skp020.asp?KPLFDNR=%s&history=true" % (self.config['scraper']['base_url'], person_id)
-    
-    logging.info("Getting person organization from %s", url)
-    # stupid re-try concept because AllRis sometimes misses start < at tags at first request
-    try_counter = 0
-    while True:
-      try:
-        response = self.get_url(url)
-        if not url:
-          return
-        tree = html.fromstring(response.text)
-          
-        memberships = []
-        person = Person(originalId=person_id)
-        # maps name of type to form name and membership type
-        type_map = {
-          u'Rat der Stadt' : {'mtype' : 'parliament', 'field' : 'PALFDNR'},
-          u'Parlament' : {'mtype' : 'parliament', 'field' : 'PALFDNR'},
-          u'Fraktion' : {'mtype' : 'organisation', 'field' : 'FRLFDNR'},
-          'Fraktionen': {'mtype' : 'parliament', 'field' : 'FRLFDNR'},
-          u'Ausschüsse' : {'mtype' : 'organization', 'field' : 'AULFDNR'},
-          'Stadtbezirk': {'mtype' : 'parliament', 'field' : 'PALFDNR'},
-          'BVV': {'mtype' : 'parliament', 'field' : 'PALFDNR'},
-          'Bezirksparlament': {'mtype' : 'parliament', 'field' : 'PALFDNR'},
-          'Bezirksverordnetenversammlung': {'mtype' : 'parliament', 'field' : 'PALFDNR'}
-        }
-    
-        # obtain the table with the membership list via a simple state machine
-        mtype = "parliament"
-        field = 'PALFDNR'
-        old_group_id = None         # for checking if it changes
-        old_group_name = None       # for checking if it changes
-        group_id = None             # might break otherwise
-        table = tree.xpath('//*[@id="rismain_raw"]/table[2]')
-        if len(table):
-          table = table[0]
-          for line in table.findall("tr"):
-            if line[0].tag == "th":
-              what = line[0].text.strip()
-              field = None
-              field_list = None
-              if what in type_map:
-                mtype = type_map[what]['mtype']
-                field = type_map[what]['field']
-              elif 'Wahlperiode' in what:
-                mtype = 'parliament'
-                field_list = ['KPLFDNR', 'AULFDNR'] # 'FRLFDNR'
-              elif "Auskünfte gemäß BVV" in what:
-                break
-              else:
-                logging.error("Unknown organization type %s at person detail page %s", what, person_id)
-                continue
-            else:
-              if "Keine Information" in line.text_content():
-                # skip because no content is available
-                continue
-              
-              # Empty line = strange stuff comes after this
-              if len(list(line)) < 2:
-                break
-              
-              # first get the name of group
-              group_name = line[1].text_content()
-              organization = Organization(name=group_name)
-              
-              organization.classification = mtype
-      
-              # now the first col might be a form with more useful information which will carry through until we find another one
-              # with it. we still check the name though
-              form = line[0].find("form")
-              if form is not None:
-                if field:
-                  group_id = int(form.find("input[@name='%s']" % field).get("value"))
-                elif field_list:
-                  for field in field_list:
-                    temp_form = form.find("input[@name='%s']" % field)
-                    if temp_form is not None:
-                      group_id = int(temp_form.get("value"))
-                organization.originalId = group_id
-                old_group_id = group_id # remember it for next loop
-                old_group_name = group_name # remember it for next loop
-              else:
-                # we did not find a form. We assume that the old group still applies but we nevertheless check if the groupname is still the same
-                if old_group_name != group_name:
-                  logging.warn("Group name differs but we didn't get a form with new group id: group name=%s, old group name=%s, old group id=%s at url %s", group_name, old_group_name, old_group_id, url)
-                  organization.originalId = None
+    def find_person(self):
+        find_person_url = (self.config['scraper']['base_url'] +
+                           'kp041.asp?template=xyz&selfaction=ws&showAll=true&'
+                           'PALFDNRM=1&kpdatfil=&filtdatum=filter&kpname=&'
+                           'kpsonst=&kpampa=99999999&kpfr=99999999&'
+                           'kpamfr=99999999&kpau=99999999&kpamau=99999999&'
+                           'searchForm=true&search=Suchen')
+        logging.info("Getting person overview from %s", find_person_url)
+
+        """parse an XML file and return the tree"""
+        parser = etree.XMLParser(recover=True)
+        r = self.get_url(find_person_url)
+        if not r:
+            return
+        xml = r.text.encode('ascii', 'xmlcharrefreplace')
+        tree = etree.fromstring(xml, parser=parser)
+        h = HTMLParser.HTMLParser()
+
+        # element 0 is the special block
+        # element 1 is the list of persons
+        for node in tree[1].iterchildren():
+            elem = {}
+            for e in node.iterchildren():
+                if e.text:
+                    elem[e.tag] = h.unescape(e.text)
                 else:
-                  organization.originalId = old_group_id
-              membership = Membership(organization=organization)
-              membership.originalId = unicode(person_id) + '-' + unicode(group_id)
-              
-              # TODO: create a list of functions so we can index them somehow
-              function = line[2].text_content()
-              raw_date = line[3].text_content()
-              # parse the date information
-              if "seit" in raw_date:
-                dparts = raw_date.split()
-                membership.endDate = dparts[-1]
-              elif "Keine" in raw_date or raw_date.strip() == '':
-                # no date information available
-                start_date = end_date = None
-              else:
-                dparts = raw_date.split()
-                membership.startDate = dparts[0]
-                membership.endDate = dparts[-1]
-              if organization.originalId is not None:
-                memberships.append(membership)
-              else:
-                logging.warn("Bad organization at %s" % (url))
-              
-          person.membership = memberships
-          oid = self.db.save_person(person)
-          return
-        else:
-          logging.info("table missing, nothing to do at %s" % url)
-          return
-      except (AttributeError):
-        if try_counter < 3:
-          logging.info("Try again: Getting person organizations with person id %d from %s", person_id, url)
-          try_counter += 1
-        else:
-          logging.error("Failed getting person organizations with person id %d from %s", person_id, url)
-          return
-    
-  
-  def get_person_organization_presence(self, person_id=None, person_url=None):
-    # URL is like si019.asp?SILFDNR=5672
-    # TODO
-    pass
-  
+                    elem[e.tag] = ''
 
-  def get_meeting(self, meeting_url=None, meeting_id=None):
-    """
-    Load meeting details (e.g. agendaitems) for the given detail page URL or numeric ID
-    """
-    meeting_url = "%sto010.asp?selfaction=ws&template=xyz&SILFDNR=%s" % (self.config['scraper']['base_url'], meeting_id)
-    
-    logging.info("Getting meeting %d from %s", meeting_id, meeting_url)
-    
-    r = self.get_url(meeting_url)
-    if not r:
-      return
-    # If r.history has an item we have a problem
-    if len(r.history):
-      if r.history[0].status_code == 302:
-        logging.info("Meeting %d from %s seems to be private", meeting_id, meeting_id)
-      else:
-        logging.error("Strange redirect %d from %s with status code %s", meeting_id, meeting_url, r.history[0].status_code)
-      return
-    h = HTMLParser.HTMLParser()
-    xml = str(r.text.encode('ascii','xmlcharrefreplace'))
-    parser = etree.XMLParser(recover=True)
-    root = etree.fromstring(xml, parser=parser)
-    
-    meeting = Meeting(originalId=meeting_id)
+            # now retrieve person details such as organization memberships etc.
+            # we also get the age (but only that, no date of birth)
+            person = Person(originalId=int(elem['kplfdnr']))
+            if elem['link_kp']:
+                person.originalUrl = elem['link_kp']
+            # personal information
 
-    # special area
-    special = {}
-    for item in root[0].iterchildren():
-      special[item.tag] = item.text
-    # Woher kriegen wir das Datum? Nur über die Übersicht?
-    #if 'sisb' in special:
-    #if 'sise' in special:
-    if 'saname' in special:
-      meeting.type = special['saname']
-    # head area
-    head = {}
-    for item in root[1].iterchildren():
-      if item.text:
-        head[item.tag] = h.unescape(item.text)
-      else:
-        head[item.text] = ''
-    if 'sitext' in head:
-      meeting.name = head['sitext']
-    if 'raname' in head:
-      meeting.room = head['raname']
-    if 'raort' in head:
-      meeting.address = head['raort']
-    agendaitems = []
-    
-    for item in root[2].iterchildren():
-      elem = {}
-      for e in item.iterchildren():
-        elem[e.tag] = e.text
+            if elem['adtit']:
+                person.title = elem['adtit']
+            if elem['antext1'] == 'Frau':
+                person.sex = 1
+            elif elem['antext1'] == 'Herr':
+                person.sex = 2
+            if elem['advname']:
+                person.firstname = elem['advname']
+            if elem['adname']:
+                person.lastname = elem['adname']
 
-      section = [elem['tofnum'], elem['tofunum'], elem['tofuunum']]
-      section = [x for x in section if x!="0"]
-      elem['section'] = ".".join(section)
-      agendaitem = AgendaItem()
-      
-      agendaitem.originalId = int(elem['tolfdnr'])
-      if elem['toostLang'] == u'öffentlich':
-        agendaitem.public = True
-      else:
-        agendaitem.public = False
-      #agendaitem.name = elem['totext1']
-      # get agenda detail page
-      # TODO: Own Queue
-      time.sleep(self.config['scraper']['wait_time'])
-      agendaitem_url = '%sto020.asp?selfaction=ws&template=xyz&TOLFDNR=%s' % (self.config['scraper']['base_url'], agendaitem.originalId)
-      logging.info("Getting agendaitem %d from %s", agendaitem.originalId, agendaitem_url)
-      
-      agendaitem_r = self.get_url(agendaitem_url)
-      if not agendaitem_r:
-        return
-      
-      if len(agendaitem_r.history):
-        logging.info("Agenda item %d from %s seems to be private", meeting_id, meeting_url)
-      else:
-        agendaitem_xml = agendaitem_r.text.encode('ascii','xmlcharrefreplace')
-        agendaitem_parser = etree.XMLParser(recover=True)
-        agendaitem_root = etree.fromstring(agendaitem_xml, parser=parser)
-        add_agenda_item = {}
-        for add_item in agendaitem_root[0].iterchildren():
-          if add_item.tag == "rtfWP" and len(add_item) > 0:
+            # address
+            if elem['adstr']:
+                person.address = elem['adstr']
+            if elem['adhnr']:
+                person.house_number = elem['adhnr']
+            if elem['adplz']:
+                person.postalcode = elem['adplz']
+            if elem['adtel']:
+                person.phone = elem['adtel']
+
+            # contact
+            if elem['adtel']:
+                person.phone = elem['adtel']
+            if elem['adtel2']:
+                person.mobile = elem['adtel2']
+            if elem['adfax']:
+                person.fax = elem['adfax']
+            if elem['adfax']:
+                person.fax = elem['adfax']
+            if elem['ademail']:
+                person.email = elem['ademail']
+            if elem['adwww1']:
+                person.website = elem['adwww1']
+
+            person_party = elem['kppartei']
+            if person_party:
+                if person_party in self.config['scraper']['party_alias']:
+                    person_party = self.config['scraper']['party_alias'][person_party]
+                new_organization = Organization(originalId=person_party,
+                                                name=person_party,
+                                                classification='party')
+                original_id = unicode(person.originalId) + '-' + person_party
+                person.membership = [Membership(originalId=original_id,
+                                                organization=new_organization)]
+
+            if elem['link_kp'] is not None:
+                if hasattr(self, 'person_queue'):
+                    self.person_queue.add(person.originalId)
+            else:
+                logging.info("Person %s %s has no link", person.firstname,
+                             person.lastname)
+            self.db.save_person(person)
+
+    def find_meeting(self, start_date=None, end_date=None):
+        """ Find meetings within a given time frame and add them to the meeting
+        queue.
+        """
+        meeting_find_url = (self.config['scraper']['allris']['meeting_find_url']
+                            % (self.config['scraper']['base_url'],
+                               start_date.strftime("%d.%m.%Y"),
+                               end_date.strftime("%d.%m.%Y")))
+        logging.info("Getting meeting overview from %s", meeting_find_url)
+
+        parser = etree.XMLParser(recover=True)
+        h = HTMLParser.HTMLParser()
+
+        r = self.get_url(meeting_find_url)
+        if not r:
+            return
+
+        xml = r.text.encode('ascii', 'xmlcharrefreplace').replace('</a>', '')
+        xml = re.sub(r'<a href="([^"]*)" target="_blank" ?>', r'\1', xml)
+        root = etree.fromstring(xml, parser=parser)
+        for item in root:
+            if item.tag == 'list':
+                root = item
+                break
+        for item in root.iterchildren():
+            raw_meeting = {}
+            for e in item.iterchildren():
+                if e.text:
+                    raw_meeting[e.tag] = h.unescape(e.text)
+                else:
+                    raw_meeting[e.tag] = ''
+            meeting = Meeting(originalId=int(raw_meeting['silfdnr']))
+            meeting.start = self.parse_date(raw_meeting['sisbvcs'])
+            meeting.end = self.parse_date(raw_meeting['sisevcs'])
+            meeting.name = raw_meeting['siname']
+            meeting.originalUrl = ("%sto010.asp?SILFDNR=%s&options=4"
+                                   % (self.config['scraper']['base_url'],
+                                      raw_meeting['silfdnr']))
+            meeting.name = raw_meeting['sitext']
+            meeting.organization_name = raw_meeting['grname']
+            # meeting.description = raw_meeting['sitext'] # WHAT TO DO WITH THIS
+            self.db.save_meeting(meeting)
+            self.meeting_queue.add(meeting.originalId)
+
+    def get_organization(self, organization_id=None, organization_url=None):
+        pass
+
+    def get_person(self, person_id=None, person_url=None):
+        # we dont need this(?)
+        pass
+
+    def get_person_organization(self, person_id=None, organization_url=None):
+        url = ("%skp020.asp?KPLFDNR=%s&history=true"
+               % (self.config['scraper']['base_url'], person_id))
+
+        logging.info("Getting person organization from %s", url)
+        # Stupid re-try concept because AllRis sometimes misses start < at
+        # tags at first request.
+        try_counter = 0
+        while True:
             try:
-              agendaitem.resolution_text = h.unescape(etree.tostring(add_item[0][1][0]))
-            except:
-              logging.warn("Unable to parse resolution text at %s", agendaitem_url)
-          else:
-            if add_item.text:
-              add_agenda_item[add_item.tag] = h.unescape(add_item.text)
-        if 'toptext' in add_agenda_item:
-          agendaitem.name = add_agenda_item['toptext']
-        
-        # there are papers with id = 0. we don't need them.
-        if int(elem['volfdnr']):
-          consultation = Consultation(originalId=unicode(agendaitem.originalId) + unicode(int(elem['volfdnr'])))
-          if 'voname' in add_agenda_item:
-            consultation.paper = Paper(originalId = int(elem['volfdnr']), name=add_agenda_item['voname'])
-          else:
-            consultation.paper = Paper(originalId = int(elem['volfdnr']))
-          agendaitem.consultation = [consultation]
-          if 'vobetr' in add_agenda_item:
-            if add_agenda_item['vobetr'] != agendaitem.name:
-              logging.warn("different values for name: %s and %s", agendaitem.name, add_agenda_item['vobetr'])
-          if hasattr(self, 'paper_queue'):
-            self.paper_queue.add(int(elem['volfdnr']))
-        if 'totyp' in add_agenda_item:
-          agendaitem.result = add_agenda_item['totyp']
-        agendaitems.append(agendaitem)
-    meeting.agendaItem = agendaitems
-    
-    oid = self.db.save_meeting(meeting)
-    logging.info("Meeting %d stored with _id %s", meeting_id, oid)
-    
+                response = self.get_url(url)
+                if not url:
+                    return
+                tree = html.fromstring(response.text)
 
-  def get_paper(self, paper_url=None, paper_id=None):
-    """
-    Load paper details for the paper given by detail page URL
-    or numeric ID
-    """
-    paper_url = '%svo020.asp?VOLFDNR=%s' % (self.config['scraper']['base_url'], paper_id)
-    logging.info("Getting paper %d from %s", paper_id, paper_url)
+                memberships = []
+                person = Person(originalId=person_id)
+                # maps name of type to form name and membership type
+                type_map = {
+                    u'Rat der Stadt' : {'mtype' : 'parliament',
+                                        'field' : 'PALFDNR'},
+                    u'Parlament' : {'mtype' : 'parliament',
+                                    'field' : 'PALFDNR'},
+                    u'Fraktion' : {'mtype' : 'organisation',
+                                   'field' : 'FRLFDNR'},
+                    'Fraktionen': {'mtype' : 'parliament', 'field' : 'FRLFDNR'},
+                    u'Ausschüsse' : {'mtype' : 'organization',
+                                     'field' : 'AULFDNR'},
+                    'Stadtbezirk': {'mtype' : 'parliament',
+                                    'field' : 'PALFDNR'},
+                    'BVV': {'mtype' : 'parliament', 'field' : 'PALFDNR'},
+                    'Bezirksparlament': {'mtype' : 'parliament',
+                                         'field' : 'PALFDNR'},
+                    'Bezirksverordnetenversammlung': {'mtype' : 'parliament',
+                                                      'field' : 'PALFDNR'}
+                }
 
-    # stupid re-try concept because AllRis sometimes misses start < at tags at first request
-    try_counter = 0
-    while True:
-      try:
-        response = self.get_url(paper_url)
-        if not response:
-          return
-        if "noauth" in response.url:
-          logging.warn("Paper %s in %s seems to private" % (paper_id, paper_url))
-          return
-        text = response.text
-        doc = html.fromstring(text)
-        data = {}
-        
-        # Beratungsfolge-Table checken
-        table = self.table_css(doc)[0] # lets hope we always have this table
-        self.consultation_list_start = False
-        last_headline = ''
-        for line in table:
-          if line.tag == 'tr':
-            headline = line[0].text
-          elif line.tag == 'td':
-            headline = line.text
-          else:
-            logging.error("ERROR: Serious error in data table. Unable to parse.")
-          if headline:
-            headline = headline.split(":")[0].lower()
-            if headline[-1]==":":
-              headline = headline[:-1]
-            if headline == "betreff":
-              value = line[1].text_content().strip()
-              value = value.split("-->")[1]         # there is some html comment with a script tag in front of the text which we remove
-              data[headline] = " ".join(value.split())  # remove all multiple spaces from the string
-            elif headline in ['verfasser', u'federführend', 'drucksache-art']:
-              data[headline] = line[1].text.strip()
-            elif headline in ['status']:
-              data[headline] = line[1].text.strip()
-              # related papers
-              if len(line) > 2:
-                if len(line[3]):
-                  # gets originalId. is there something else at this position? (will break)
-                  data['relatedPaper'] = [Paper(originalId=line[3][0][0][1][0].get('href').split('=')[1].split('&')[0])]
-            
-            # Lot's of scraping just because of the date (?)
-            elif headline == "beratungsfolge":
-              # the actual list will be in the next row inside a table, so we only set a marker
-              self.consultation_list_start = True
-            elif self.consultation_list_start:
-              elem = line[0][0]
-              # the first line is pixel images, so skip it, then we need to jump in steps of two
-              amount = (len(elem)-1)/2
-              consultations = []
-              date_list = []
-              i = 0
-              item = None
-              for elem_line in elem:
-                if i == 0:
-                  i=i+1
-                  continue
-                
-                """
-                here we need to parse the actual list which can have different forms. A complex example
-                can be found at http://ratsinfo.aachen.de/bi/vo020.asp?VOLFDNR=10822
-                The first line is some sort of headline with the committee in question and the type of consultation.
-                After that 0-n lines of detailed information of meetings with a date, transscript and decision.
-                The first line has 3 columns (thanks to colspan) and the others have 7.
-            
-                Here we make every meeting a separate entry, we can group them together later again if we want to.
-               """
-                
-                # now we need to parse the actual list
-                # those lists
-                new_consultation = Consultation()
-                new_consultation.status = elem_line[0].attrib['title'].lower()
-                if len(elem_line) == 3:
-                  # the order is "color/status", name of committee / link to TOP, more info
-                  # we define a head dict here which can be shared for the other lines
-                  # once we find another head line we will create a new one here
-                  new_consultation.role = elem_line[2].text.strip()
-                  
-                    #'committee' : elem_line[1].text.strip(), # name of committee, e.g. "Finanzausschuss", unfort. without id
-                # for some obscure reasons sometimes action is missing
-                elif len(elem_line) == 2:
-                  # the order is "color/status", name of committee / link to TOP, more info
-                  status = elem_line[0].attrib['title'].lower()
-                  # we define a head dict here which can be shared for the other lines
-                  # once we find another head line we will create a new one here
-                    #'committee' : elem_line[1].text.strip(), # name of committee, e.g. "Finanzausschuss", unfort. without id
-                elif len(elem_line) == 7:
-                  try:
-                    # this is about line 2 with lots of more stuff to process
-                    # date can be text or a link with that text
-                    if len(elem_line[1]) == 1: # we have a link (and ignore it)
-                      date_list.append(datetime.datetime.strptime(elem_line[1][0].text.strip(), "%d.%m.%Y"))
+                # obtain the table with the membership list via a simple state machine
+                mtype = "parliament"
+                field = 'PALFDNR'
+                # for checking if it changes
+                old_group_id = None
+                # for checking if it changes
+                old_group_name = None
+                # might break otherwise
+                group_id = None
+                table = tree.xpath('//*[@id="rismain_raw"]/table[2]')
+                if len(table):
+                    table = table[0]
+                    for line in table.findall("tr"):
+                        if line[0].tag == "th":
+                            what = line[0].text.strip()
+                            field = None
+                            field_list = None
+                            if what in type_map:
+                                mtype = type_map[what]['mtype']
+                                field = type_map[what]['field']
+                            elif 'Wahlperiode' in what:
+                                mtype = 'parliament'
+                                # 'FRLFDNR'
+                                field_list = ['KPLFDNR', 'AULFDNR']
+                            elif "Auskünfte gemäß BVV" in what:
+                                break
+                            else:
+                                logging.error("Unknown organization type %s "
+                                              "at person detail page %s",
+                                              what, person_id)
+                                continue
+                        else:
+                            if "Keine Information" in line.text_content():
+                                # skip because no content is available
+                                continue
+
+                            # Empty line = strange stuff comes after this
+                            if len(list(line)) < 2:
+                                break
+
+                            # first get the name of group
+                            group_name = line[1].text_content()
+                            organization = Organization(name=group_name)
+
+                            organization.classification = mtype
+
+                            # Now the first col might be a form with more
+                            # useful information which will carry through
+                            # until we find another one.
+                            # With it. we still check the name though.
+                            form = line[0].find("form")
+                            if form is not None:
+                                if field:
+                                    group_id = int(form.find(
+                                        "input[@name='%s']" % field).get(
+                                            "value"))
+                                elif field_list:
+                                    for field in field_list:
+                                        temp_form = form.find(
+                                            "input[@name='%s']" % field)
+                                        if temp_form is not None:
+                                            group_id = int(temp_form.get(
+                                                "value"))
+                                organization.originalId = group_id
+                                # remember it for next loop
+                                old_group_id = group_id
+                                # remember it for next loop
+                                old_group_name = group_name
+                            else:
+                                # We did not find a form. We assume that the
+                                # old group still applies but we nevertheless
+                                # check if the groupname is still the same.
+                                if old_group_name != group_name:
+                                    logging.warn("Group name differs but we "
+                                                 "didn't get a form with new "
+                                                 "group id: group name=%s, old "
+                                                 "group name=%s, old group "
+                                                 "id=%s at url %s",
+                                                 group_name, old_group_name,
+                                                 old_group_id, url)
+                                    organization.originalId = None
+                                else:
+                                    organization.originalId = old_group_id
+                            membership = Membership(organization=organization)
+                            membership.originalId = (unicode(person_id) + '-'
+                                                     + unicode(group_id))
+
+                            # TODO: create a list of functions so we can
+                            #       index them somehow
+                            function = line[2].text_content()
+                            raw_date = line[3].text_content()
+                            # parse the date information
+                            if "seit" in raw_date:
+                                dparts = raw_date.split()
+                                membership.endDate = dparts[-1]
+                            elif "Keine" in raw_date or not raw_date.strip():
+                                # no date information available
+                                start_date = end_date = None
+                            else:
+                                dparts = raw_date.split()
+                                membership.startDate = dparts[0]
+                                membership.endDate = dparts[-1]
+                            if organization.originalId is not None:
+                                memberships.append(membership)
+                            else:
+                                logging.warn("Bad organization at %s", url)
+
+                    person.membership = memberships
+                    oid = self.db.save_person(person)
+                    return
+                else:
+                    logging.info("table missing, nothing to do at %s", url)
+                    return
+            except AttributeError:
+                if try_counter < 3:
+                    logging.info("Try again: Getting person organizations with "
+                                 "person id %d from %s", person_id, url)
+                    try_counter += 1
+                else:
+                    logging.error("Failed getting person organizations with "
+                                  "person id %d from %s", person_id, url)
+                    return
+
+
+    def get_person_organization_presence(self, person_id=None, person_url=None):
+        # URL is like si019.asp?SILFDNR=5672
+        # TODO
+        pass
+
+
+    def get_meeting(self, meeting_url=None, meeting_id=None):
+        """ Load meeting details (e.g. agendaitems) for the given detail page
+        URL or numeric ID
+        """
+        meeting_url = ("%sto010.asp?selfaction=ws&template=xyz&SILFDNR=%s"
+                       % (self.config['scraper']['base_url'], meeting_id))
+
+        logging.info("Getting meeting %d from %s", meeting_id, meeting_url)
+
+        r = self.get_url(meeting_url)
+        if not r:
+            return
+        # If r.history has an item we have a problem
+        if len(r.history):
+            if r.history[0].status_code == 302:
+                logging.info("Meeting %d from %s seems to be private",
+                             meeting_id, meeting_id)
+            else:
+                logging.error("Strange redirect %d from %s with status code %s",
+                              meeting_id, meeting_url, r.history[0].status_code)
+            return
+        h = HTMLParser.HTMLParser()
+        xml = str(r.text.encode('ascii', 'xmlcharrefreplace'))
+        parser = etree.XMLParser(recover=True)
+        root = etree.fromstring(xml, parser=parser)
+
+        meeting = Meeting(originalId=meeting_id)
+
+        # special area
+        special = {}
+        for item in root[0].iterchildren():
+            special[item.tag] = item.text
+        # Woher kriegen wir das Datum? Nur über die Übersicht?
+        #if 'sisb' in special:
+        #if 'sise' in special:
+        if 'saname' in special:
+            meeting.type = special['saname']
+        # head area
+        head = {}
+        for item in root[1].iterchildren():
+            if item.text:
+                head[item.tag] = h.unescape(item.text)
+            else:
+                head[item.text] = ''
+        if 'sitext' in head:
+            meeting.name = head['sitext']
+        if 'raname' in head:
+            meeting.room = head['raname']
+        if 'raort' in head:
+            meeting.address = head['raort']
+        agendaitems = []
+
+        for item in root[2].iterchildren():
+            elem = {}
+            for e in item.iterchildren():
+                elem[e.tag] = e.text
+
+            section = [elem['tofnum'], elem['tofunum'], elem['tofuunum']]
+            section = [x for x in section if x != "0"]
+            elem['section'] = ".".join(section)
+            agendaitem = AgendaItem()
+
+            agendaitem.originalId = int(elem['tolfdnr'])
+            agendaitem.public = (elem['toostLang'] == u'öffentlich')
+            #agendaitem.name = elem['totext1']
+            # get agenda detail page
+            # TODO: Own Queue
+            time.sleep(self.config['scraper']['wait_time'])
+            agendaitem_url = ('%sto020.asp?selfaction=ws&template=xyz&TOLFDNR=%s'
+                              % (self.config['scraper']['base_url'],
+                                 agendaitem.originalId))
+            logging.info("Getting agendaitem %d from %s",
+                         agendaitem.originalId, agendaitem_url)
+
+            agendaitem_r = self.get_url(agendaitem_url)
+            if not agendaitem_r:
+                return
+
+            if len(agendaitem_r.history):
+                logging.info("Agenda item %d from %s seems to be private",
+                             meeting_id, meeting_url)
+            else:
+                agendaitem_xml = agendaitem_r.text.encode('ascii',
+                                                          'xmlcharrefreplace')
+                # TODO: mixup of agendaitem_parser / parser below?
+                agendaitem_parser = etree.XMLParser(recover=True)
+                agendaitem_root = etree.fromstring(agendaitem_xml,
+                                                   parser=parser)
+                add_agenda_item = {}
+                for add_item in agendaitem_root[0].iterchildren():
+                    if add_item.tag == "rtfWP" and len(add_item) > 0:
+                        try:
+                            agendaitem.resolution_text = h.unescape(
+                                etree.tostring(add_item[0][1][0]))
+                        except:
+                            logging.warn("Unable to parse resolution text at "
+                                         "%s", agendaitem_url)
                     else:
-                      date_list.append(datetime.datetime.strptime(elem_line[1].text.strip(), "%d.%m.%Y"))
-                    if len(elem_line[2]):
-                      form = elem_line[2][0] # form with silfdnr and toplfdnr but only in link (action="to010.asp?topSelected=57023")
-                      new_consultation.meeting = [Meeting(originalId=form[0].attrib['value'])]
-                      #item['meeting'] = elem_line[3][0].text.strip()     # full name of meeting, e.g. "A/31/WP.16 öffentliche/nichtöffentliche Sitzung des Finanzausschusses"
+                        if add_item.text:
+                            add_agenda_item[add_item.tag] = h.unescape(
+                                add_item.text)
+                if 'toptext' in add_agenda_item:
+                    agendaitem.name = add_agenda_item['toptext']
+
+                # there are papers with id = 0. we don't need them.
+                if int(elem['volfdnr']):
+                    consult_id = (unicode(agendaitem.originalId)
+                                  + unicode(int(elem['volfdnr'])))
+                    consultation = Consultation(originalId=consult_id)
+                    paper_id = int(elem['volfdnr'])
+                    if 'voname' in add_agenda_item:
+                        consultation.paper = Paper(
+                            originalId=paper_id, name=add_agenda_item['voname'])
                     else:
-                      #no link to TOP. should not be possible but happens (TODO: Bugreport?)
-                      #item['meeting'] = elem_line[3].text.strip()   # here we have no link but the text is in the TD directly - will be scaped as meeting
-                      logging.warn("AgendaItem in consultation list on the web page does not contain a link to the actual meeting at paper %s", paper_url)
-                    toplfdnr = None
-                    if len(elem_line[6]) > 0:
-                      form = elem_line[6][0]
-                      toplfdnr = form[0].attrib['value']
-                    if toplfdnr:
-                      new_consultation.originalId = "%s-%s" % (toplfdnr, paper_id)
-                      new_consultation.agendaItem = AgendaItem(originalId=toplfdnr)           # actually the id of the transcript
-                      new_consultation.agendaItem.result = elem_line[4].text.strip()     # e.g. "ungeändert beschlossen"
-                      consultations.append(new_consultation)
+                        consultation.paper = Paper(originalId=paper_id)
+                    agendaitem.consultation = [consultation]
+                    if 'vobetr' in add_agenda_item:
+                        if add_agenda_item['vobetr'] != agendaitem.name:
+                            logging.warn("different values for name: %s and %s",
+                                         agendaitem.name,
+                                         add_agenda_item['vobetr'])
+                    if hasattr(self, 'paper_queue'):
+                        self.paper_queue.add(int(elem['volfdnr']))
+                if 'totyp' in add_agenda_item:
+                    agendaitem.result = add_agenda_item['totyp']
+                agendaitems.append(agendaitem)
+        meeting.agendaItem = agendaitems
+
+        oid = self.db.save_meeting(meeting)
+        logging.info("Meeting %d stored with _id %s", meeting_id, oid)
+
+
+    def get_paper(self, paper_url=None, paper_id=None):
+        """
+        Load paper details for the paper given by detail page URL
+        or numeric ID
+        """
+        paper_url = ('%svo020.asp?VOLFDNR=%s'
+                     % (self.config['scraper']['base_url'], paper_id))
+        logging.info("Getting paper %d from %s", paper_id, paper_url)
+
+        # Stupid re-try concept because AllRis sometimes misses
+        # start < at tags at first request.
+        try_counter = 0
+        while True:
+            try:
+                response = self.get_url(paper_url)
+                if not response:
+                    return
+                if "noauth" in response.url:
+                    logging.warn("Paper %s in %s seems to private",
+                                 paper_id, paper_url)
+                    return
+                text = response.text
+                doc = html.fromstring(text)
+                data = {}
+
+                # Beratungsfolge-Table checken
+                # lets hope we always have this table
+                table = self.table_css(doc)[0]
+                self.consultation_list_start = False
+                last_headline = ''
+                for line in table:
+                    if line.tag == 'tr':
+                        headline = line[0].text
+                    elif line.tag == 'td':
+                        headline = line.text
                     else:
-                      logging.error("missing agendaItem ID in consultation list at %s" % paper_url)
-                  except (IndexError, KeyError):
-                    logging.error("ERROR: Serious error in consultation list. Unable to parse.")
-                    logging.error("Serious error in consultation list. Unable to parse.")
-                    return []
-                i=i+1
-              # Theory: we don't need this at all, because it's scraped at meeting
-              #data['consultations'] = consultations
-              self.consultation_list_start = False # set the marker to False again as we have read it
-          last_headline = headline
-          # we simply ignore the rest (there might not be much more actually)
-        # the actual text comes after the table in a div but it's not valid XML or HTML this using regex
-        data['docs'] = self.body_re.findall(response.text)
-        first_date = False
-        for single_date in date_list:
-          if first_date:
-            if single_date < first_date:
-              first_date = single_date
-          else:
-            first_date = single_date
-        paper = Paper(originalId = paper_id)
-        paper.originalUrl = paper_url
-        paper.name = data['betreff']
-        paper.description = data['docs']
-        if 'drucksache-art' in data:
-          paper.paperType = data['drucksache-art']
-        if first_date:
-          paper.publishedDate = first_date.strftime("%d.%m.%Y")
-        # see theory above
-        #if 'consultations' in data:
-        #  paper.consultation = data['consultations']
-        paper.auxiliaryFile = []
-        # get the attachments step 1 (Drucksache)
-        file_1 = self.attachment_1_css(doc)
-        if len(file_1):
-          if file_1[0].value:
-            href = '%sdo027.asp' % self.config['scraper']['base_url']
-            originalId = file_1[0].value
-            name = 'Drucksache'
-            file = File(
-              originalId=originalId,
-              name=name)
-            file = self.get_file(file, href, True)
-            paper.mainFile = file
-        # get the attachments step 2 (additional attachments)
-        files = self.attachments_css(doc)
-        if len(files) > 0:
-          if len(files[0]) > 1:
-            if files[0][1][0].text.strip() == "Anlagen:":
-              for tr in files[0][2:]:
-                link = tr[0][0]
-                href = "%s%s" % (self.config['scraper']['base_url'], link.attrib["href"])
-                name = link.text
-                originalId = str(int(link.attrib["href"].split('/')[4])) + '-' + str(int(link.attrib["href"].split('/')[6]))
-                file = File(
-                  originalId=originalId,
-                  name=name)
-                file = self.get_file(file, href)
-                paper.auxiliaryFile.append(file)
-        print paper.auxiliaryFile
-        if not len(paper.auxiliaryFile):
-          del paper.auxiliaryFile
-        oid = self.db.save_paper(paper)
-        return
-      except (KeyError, IndexError):
-        if try_counter < 3:
-          logging.info("Try again: Getting paper %d from %s", paper_id, paper_url)
-          try_counter += 1
+                        logging.error("ERROR: Serious error in data table. "
+                                      "Unable to parse.")
+                    if headline:
+                        headline = headline.split(":")[0].lower()
+                        if headline[-1] == ":":
+                            headline = headline[:-1]
+                        if headline == "betreff":
+                            value = line[1].text_content().strip()
+                            # There is some html comment with a script
+                            # tag in front of the text which we remove.
+                            value = value.split("-->")[1]
+                            # remove all multiple spaces from the string
+                            data[headline] = " ".join(value.split())
+                        elif headline in ['verfasser', u'federführend',
+                                          'drucksache-art']:
+                            data[headline] = line[1].text.strip()
+                        elif headline in ['status']:
+                            data[headline] = line[1].text.strip()
+                            # related papers
+                            if len(line) > 2:
+                                if len(line[3]):
+                                    # Gets originalId. is there something
+                                    # else at this position? (will break)
+                                    paper_id = line[3][0][0][1][0].get(
+                                        'href').split('=')[1].split('&')[0]
+                                    data['relatedPaper'] = [Paper(
+                                        originalId=paper_id)]
+
+                        # Lot's of scraping just because of the date (?)
+                        elif headline == "beratungsfolge":
+                            # The actual list will be in the next row
+                            # inside a table, so we only set a marker.
+                            self.consultation_list_start = True
+                        elif self.consultation_list_start:
+                            elem = line[0][0]
+                            # The first line is pixel images, so skip
+                            # it, then we need to jump in steps of two.
+                            amount = (len(elem) - 1) / 2
+                            consultations = []
+                            date_list = []
+                            i = 0
+                            item = None
+                            for elem_line in elem:
+                                if i == 0:
+                                    i += 1
+                                    continue
+
+                                """
+                                Here we need to parse the actual list which can have different forms. A complex example
+                                can be found at http://ratsinfo.aachen.de/bi/vo020.asp?VOLFDNR=10822
+                                The first line is some sort of headline with the committee in question and the type of consultation.
+                                After that 0-n lines of detailed information of meetings with a date, transscript and decision.
+                                The first line has 3 columns (thanks to colspan) and the others have 7.
+
+                                Here we make every meeting a separate entry, we can group them together later again if we want to.
+                                """
+
+                                # now we need to parse the actual list
+                                # those lists
+                                new_consultation = Consultation()
+                                new_consultation.status = \
+                                        elem_line[0].attrib['title'].lower()
+                                if len(elem_line) == 3:
+                                    # The order is "color/status", name of
+                                    # committee / link to TOP, more info we
+                                    # define a head dict here which can be
+                                    # shared for the other lines once we find
+                                    # another head line we will create a new
+                                    # one here.
+                                    new_consultation.role = \
+                                            elem_line[2].text.strip()
+
+                                    # Name of committee, e.g.
+                                    # "Finanzausschuss", unfort. without id
+                                    #'committee' : elem_line[1].text.strip(),
+                                # For some obscure reasons sometimes action
+                                # is missing.
+                                elif len(elem_line) == 2:
+                                    # The order is "color/status", name of
+                                    # committee / link to TOP, more info.
+                                    status = \
+                                            elem_line[0].attrib['title'].lower()
+                                    # We define a head dict here which can be
+                                    # shared for the other lines once we find
+                                    # another head line we will create a new
+                                    # one here.
+                                    # name of committee, e.g.
+                                    # "Finanzausschuss", unfort. without id
+                                    #'committee' : elem_line[1].text.strip(),
+                                elif len(elem_line) == 7:
+                                    try:
+                                        # This is about line 2 with lots of
+                                        # more stuff to process.
+                                        # Date can be text or a link with that
+                                        # text.
+                                        # We have a link (and ignore it).
+                                        if len(elem_line[1]) == 1:
+                                            date_text = elem_line[1][0].text
+                                        else:
+                                            date_text = elem_line[1].text
+                                        date_list.append(
+                                            datetime.datetime.strptime(
+                                                date_text.strip(), "%d.%m.%Y"))
+                                        if len(elem_line[2]):
+                                            # Form with silfdnr and toplfdnr
+                                            # but only in link (action=
+                                            #   "to010.asp?topSelected=57023")
+                                            form = elem_line[2][0]
+                                            meeting_id = form[0].attrib['value']
+                                            new_consultation.meeting = [Meeting(
+                                                originalId=meeting_id)]
+                                            # Full name of meeting, e.g.
+                                            # "A/31/WP.16 öffentliche/
+                                            #   nichtöffentliche Sitzung des
+                                            # Finanzausschusses"
+                                            #item['meeting'] = \
+                                            #    elem_line[3][0].text.strip()
+                                        else:
+                                            # No link to TOP. Should not be
+                                            # possible but happens.
+                                            #   (TODO: Bugreport?)
+                                            # Here we have no link but the text
+                                            # is in the TD directly - will be
+                                            # scaped as meeting.
+                                            #item['meeting'] = \
+                                            #    elem_line[3].text.strip()
+                                            logging.warn(
+                                                "AgendaItem in consultation "
+                                                "list on the web page does not "
+                                                "contain a link to the actual "
+                                                "meeting at paper %s",
+                                                paper_url)
+                                        toplfdnr = None
+                                        if len(elem_line[6]) > 0:
+                                            form = elem_line[6][0]
+                                            toplfdnr = form[0].attrib['value']
+                                        if toplfdnr:
+                                            new_consultation.originalId = \
+                                                    "%s-%s" % (toplfdnr,
+                                                               paper_id)
+                                            # actually the id of the transcript
+                                            new_consultation.agendaItem = \
+                                                    AgendaItem(
+                                                        originalId=toplfdnr)
+                                            # e.g. "ungeändert beschlossen"
+                                            new_consultation.agendaItem.result \
+                                                    = elem_line[4].text.strip()
+                                            consultations.append(
+                                                new_consultation)
+                                        else:
+                                            logging.error(
+                                                "missing agendaItem ID in "
+                                                "consultation list at %s",
+                                                paper_url)
+                                    except (IndexError, KeyError):
+                                        logging.error(
+                                            "ERROR: Serious error in "
+                                            "consultation list. Unable to "
+                                            "parse.")
+                                        logging.error(
+                                            "Serious error in consultation "
+                                            "list. Unable to parse.")
+                                        return []
+                                i += 1
+                            # Theory: we don't need this at all, because it's
+                            # scraped at meeting.
+                            #data['consultations'] = consultations
+                            # set the marker to False again as we have read it
+                            self.consultation_list_start = False
+                    last_headline = headline
+                    # We simply ignore the rest (there might not be much more
+                    # actually).
+                # The actual text comes after the table in a div but it's not
+                # valid XML or HTML this using regex.
+                data['docs'] = self.body_re.findall(response.text)
+                first_date = False
+                for single_date in date_list:
+                    if first_date:
+                        if single_date < first_date:
+                            first_date = single_date
+                    else:
+                        first_date = single_date
+                paper = Paper(originalId=paper_id)
+                paper.originalUrl = paper_url
+                paper.name = data['betreff']
+                paper.description = data['docs']
+                if 'drucksache-art' in data:
+                    paper.paperType = data['drucksache-art']
+                if first_date:
+                    paper.publishedDate = first_date.strftime("%d.%m.%Y")
+                # see theory above
+                #if 'consultations' in data:
+                #    paper.consultation = data['consultations']
+                paper.auxiliaryFile = []
+                # get the attachments step 1 (Drucksache)
+                file_1 = self.attachment_1_css(doc)
+                if len(file_1):
+                    if file_1[0].value:
+                        href = ('%sdo027.asp'
+                                % self.config['scraper']['base_url'])
+                        original_id = file_1[0].value
+                        name = 'Drucksache'
+                        main_file = File(originalId=original_id, name=name)
+                        main_file = self.get_file(main_file, href, True)
+                        paper.mainFile = main_file
+                # get the attachments step 2 (additional attachments)
+                files = self.attachments_css(doc)
+                if len(files) > 0:
+                    if len(files[0]) > 1:
+                        if files[0][1][0].text.strip() == "Anlagen:":
+                            for tr in files[0][2:]:
+                                link = tr[0][0]
+                                href = ("%s%s"
+                                        % (self.config['scraper']['base_url'],
+                                           link.attrib["href"]))
+                                name = link.text
+                                path_tokens = link.attrib["href"].split('/')
+                                original_id = "%d-%d" % (int(path_tokens[4]),
+                                                         int(path_tokens[6]))
+                                aux_file = File(originalId=original_id,
+                                                name=name)
+                                aux_file = self.get_file(aux_file, href)
+                                paper.auxiliaryFile.append(aux_file)
+                print paper.auxiliaryFile
+                if not len(paper.auxiliaryFile):
+                    del paper.auxiliaryFile
+                oid = self.db.save_paper(paper)
+                return
+            except (KeyError, IndexError):
+                if try_counter < 3:
+                    logging.info("Try again: Getting paper %d from %s",
+                                 paper_id, paper_url)
+                    try_counter += 1
+                else:
+                    logging.error("Failed getting paper %d from %s",
+                                  paper_id, paper_url)
+                    return
+
+    def get_file(self, file_obj, file_url, post=False):
+        """
+        Loads the file file from the server and stores it into
+        the file object given as a parameter. The form
+        parameter is the mechanize Form to be submitted for downloading
+        the file.
+
+        The file parameter has to be an object of type
+        model.file.File.
+        """
+        time.sleep(self.config['scraper']['wait_time'])
+        logging.info("Getting file '%s'", file_obj.originalId)
+
+        file_backup = file_obj
+        logging.info("Getting file %s from %s", file_obj.originalId, file_url)
+
+        if post:
+            file_file = self.get_url(file_url, post_data={
+                'DOLFDNR': file_obj.originalId, 'options': '64'})
         else:
-          logging.error("Failed getting paper %d from %s", paper_id, paper_url)
-          return
-    
-  def get_file(self, file, file_url, post=False):
-    """
-    Loads the file file from the server and stores it into
-    the file object given as a parameter. The form
-    parameter is the mechanize Form to be submitted for downloading
-    the file.
+            file_file = self.get_url(file_url)
+            if not file_obj:
+                logging.error("Error downloading file %s", file_url)
+                return file_obj
+        file_obj.content = file_file.content
+        # catch strange magic exception
+        try:
+            file.mimetype = magic.from_buffer(file_obj.content, mime=True)
+        except magic.MagicException:
+            logging.warn("Warning: unknown magic error at file %s from %s",
+                         file_obj.originalId, file_url)
+            return file_backup
+        file_obj.filename = self.make_filename(file_obj)
+        return file_obj
 
-    The file parameter has to be an object of type
-    model.file.File.
-    """
-    time.sleep(self.config['scraper']['wait_time'])
-    logging.info("Getting file '%s'", file.originalId)
-    
-    file_backup = file
-    logging.info("Getting file %s from %s", file.originalId, file_url)
-    
-    if post:
-      file_file = self.get_url(file_url, post_data={'DOLFDNR': file.originalId, 'options': '64'})
-    else:
-      file_file = self.get_url(file_url)
-      if not file:
-        logging.error("Error downloading file %", file_url)
-        return file
-    file.content = file_file.content
-    # catch strange magic exception
-    try:
-      file.mimetype = magic.from_buffer(file.content, mime=True)
-    except magic.MagicException:
-      logging.warn("Warning: unknown magic error at file %s from %s", file.originalId, file_url)
-      return file_backup
-    file.filename = self.make_filename(file)
-    return file
+    def make_filename(self, file_obj):
+        ext = 'dat'
 
-  def make_filename(self, file):
-    ext = 'dat'
-    
-    try:
-      name = file.name[:192]
-    except (AttributeError, TypeError):
-      name = file.originalId
-    
-    for extension in self.config['file_extensions']:
-      if extension[0] == file.mimetype:
-        ext = extension[1]
-        break
-    if ext == 'dat':
-      logging.warn("No entry in config:main:file_extensions for %s at file id %s", file.mimetype, file.originalId)
-    return name + '.' + ext
+        try:
+            name = file_obj.name[:192]
+        except (AttributeError, TypeError):
+            name = file_obj.originalId
 
-  def get_url(self, url, post_data=None):
-    retry_counter = 0
-    while retry_counter < 4:
-      retry = False
-      try:
-        if post_data is not None:
-          response = requests.post(url, post_data)
-        else:  
-          response = requests.get(url)
-        return response
-      except requests.exceptions.ConnectionError:
-        retry_counter = retry_counter + 1
-        retry = True
-        logging.info("Connection Reset while getting %s, try again", url)
-        time.sleep(self.config['scraper']['wait_time'] * 5)
-    if retry_counter == 4 and retry == True:
-      logging.critical("HTTP Error %s while getting %s", url)
-      sys.stderr.write("CRITICAL ERROR:HTTP Error while getting %s" % url)
-      return False
+        for extension in self.config['file_extensions']:
+            if extension[0] == file_obj.mimetype:
+                ext = extension[1]
+                break
+        if ext == 'dat':
+            logging.warn("No entry in config:main:file_extensions for %s at "
+                         "file id %s", file_obj.mimetype, file_obj.originalId)
+        return name + '.' + ext
 
-  # mrtopf
-  def parse_date(self, s):
-    """parse dates like 20121219T160000Z"""
-    berlin = timezone('Europe/Berlin')
-    year = int(s[0:4])
-    month = int(s[4:6])
-    day = int(s[6:8])
-    hour = int(s[9:11])
-    minute = int(s[11:13])
-    second = int(s[13:15])
-    return datetime.datetime(year, month, day, hour, minute, second, 0, tzinfo=berlin)
+    def get_url(self, url, post_data=None):
+        retry_counter = 0
+        while retry_counter < 4:
+            retry = False
+            try:
+                if post_data is not None:
+                    response = requests.post(url, post_data)
+                else:
+                    response = requests.get(url)
+                return response
+            except requests.exceptions.ConnectionError:
+                retry_counter += 1
+                retry = True
+                logging.info("Connection Reset while getting %s, try again",
+                             url)
+                time.sleep(self.config['scraper']['wait_time'] * 5)
+        if retry_counter == 4 and retry:
+            logging.critical("HTTP Error while getting %s", url)
+            sys.stderr.write("CRITICAL ERROR: HTTP Error while getting %s"
+                             % url)
+            return False
+
+    # mrtopf
+    def parse_date(self, s):
+        """parse dates like 20121219T160000Z"""
+        berlin = timezone('Europe/Berlin')
+        year = int(s[0:4])
+        month = int(s[4:6])
+        day = int(s[6:8])
+        hour = int(s[9:11])
+        minute = int(s[11:13])
+        second = int(s[13:15])
+        return datetime.datetime(year, month, day, hour, minute, second, 0,
+                                 tzinfo=berlin)
+
 
 class TemplateError(Exception):
-  def __init__(self, message):
-    Exception.__init__(self, message)
+    def __init__(self, message):
+        Exception.__init__(self, message)

--- a/risscraper/scrapersessionnet.py
+++ b/risscraper/scrapersessionnet.py
@@ -4,32 +4,45 @@
 Copyright (c) 2012 - 2015, Marian Steinbach, Ernesto Ruge
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import mechanize
-import urllib2
-import parse
-import datetime
-import time
-import queue
-import sys
-from lxml import etree
-from StringIO import StringIO
-import hashlib
-import magic
-import os
 import logging
+from StringIO import StringIO
+import time
+import sys
+import urllib2
 
-from model.body import Body
+from lxml import etree
+import magic
+import mechanize
+import parse
+
 from model.person import Person
 from model.membership import Membership
 from model.organization import Organization
@@ -38,932 +51,1073 @@ from model.consultation import Consultation
 from model.paper import Paper
 from model.agendaitem import AgendaItem
 from model.file import File
+import queue
+
 
 class ScraperSessionNet(object):
 
-  def __init__(self, config, db, options):
-  # configuration
-    self.config = config
-    # command line options and defaults
-    self.options = options
-    # database object
-    self.db = db
-    # mechanize user agent
-    self.user_agent = mechanize.Browser()
-    self.user_agent.set_handle_robots(False)
-    self.user_agent.addheaders = [('User-agent', config['scraper']['user_agent_name'])]
-    # Queues
-    if self.options.workfromqueue:
-      self.person_queue = queue.Queue('SESSIONNET_PERSON', config, db)
-      self.meeting_queue = queue.Queue('SESSIONNET_MEETING', config, db)
-      self.paper_queue = queue.Queue('SESSIONNET_PAPER', config, db)
-    # system info (PHP/ASP)
-    self.template_system = None
-    self.urls = None
-    self.xpath = None
+    def __init__(self, config, db, options):
+        # configuration
+        self.config = config
+        # command line options and defaults
+        self.options = options
+        # database object
+        self.db = db
+        # mechanize user agent
+        self.user_agent = mechanize.Browser()
+        self.user_agent.set_handle_robots(False)
+        self.user_agent.addheaders = [('User-agent',
+                                       config['scraper']['user_agent_name'])]
+        # Queues
+        if self.options.workfromqueue:
+            self.person_queue = queue.Queue('SESSIONNET_PERSON', config, db)
+            self.meeting_queue = queue.Queue('SESSIONNET_MEETING', config, db)
+            self.paper_queue = queue.Queue('SESSIONNET_PAPER', config, db)
+        # system info (PHP/ASP)
+        self.template_system = None
+        self.urls = None
+        self.xpath = None
 
-  def work_from_queue(self):
-    """
-    Empty queues if they have values. Queues are emptied in the
-    following order:
-    1. Persons
-    2. Meetings
-    3. Papers
-    """
-    while self.person_queue.has_next():
-      job = self.person_queue.get()
-      #self.get_person(committee_id=job['key'])
-      self.get_person_organization(person_id=job['key'])
-      self.person_queue.resolve_job(job)
-    while self.meeting_queue.has_next():
-      job = self.meeting_queue.get()
-      self.get_meeting(meeting_id=job['key'])
-      self.meeting_queue.resolve_job(job)
-    while self.paper_queue.has_next():
-      job = self.paper_queue.get()
-      self.get_paper(paper_id=job['key'])
-      self.paper_queue.resolve_job(job)
-    
-    # when everything is done, we remove DONE jobs
-    self.person_queue.garbage_collect()
-    self.meeting_queue.garbage_collect()
-    self.paper_queue.garbage_collect()
+    def work_from_queue(self):
+        """
+        Empty queues if they have values. Queues are emptied in the
+        following order:
+        1. Persons
+        2. Meetings
+        3. Papers
+        """
+        while self.person_queue.has_next():
+            job = self.person_queue.get()
+            #self.get_person(committee_id=job['key'])
+            self.get_person_organization(person_id=job['key'])
+            self.person_queue.resolve_job(job)
+        while self.meeting_queue.has_next():
+            job = self.meeting_queue.get()
+            self.get_meeting(meeting_id=job['key'])
+            self.meeting_queue.resolve_job(job)
+        while self.paper_queue.has_next():
+            job = self.paper_queue.get()
+            self.get_paper(paper_id=job['key'])
+            self.paper_queue.resolve_job(job)
 
-  def guess_system(self):
-    """
-    Tries to find out which SessionNet version we are working with
-    and adapts configuration
-    """
-    time.sleep(self.config['scraper']['wait_time'])
-    # requesting the base URL. This is usually redirected
-    #try:
-    #  response = self.user_agent.open(self.config['scraper']['base_url'])
-    #except urllib2.HTTPError, e:
-    #  if e.code == 404:
-    #    sys.stderr.write("URL not found (HTTP 404) error caught: %s\n" % self.config['scraper']['base_url'])
-    #    sys.stderr.write("Please check BASE_URL in your configuration.\n")
-    #    sys.exit(1)
-    #url = response.geturl()
-    #assert (url != self.config['scraper']['base_url']), "No redirect"
-    #if url.endswith('.php'):
-    #  self.template_system = 'php'
-    #elif url.endswith('.asp'):
-    #  self.template_system = 'asp'
-    #else:
-    #  logging.critical("Cannot guess template system from URL '%s'", url)
-    #  sys.stderr.write("CRITICAL ERROR: Cannot guess template system from URL '%s'\n" % url)
-    #  # there is no point in going on here.
-    #  sys.exit(1)
-    self.urls = self.config['scraper'][self.config['scraper']['type']]['urls']
-    self.xpath = self.config['scraper'][self.config['scraper']['type']]['xpath']
+        # when everything is done, we remove DONE jobs
+        self.person_queue.garbage_collect()
+        self.meeting_queue.garbage_collect()
+        self.paper_queue.garbage_collect()
 
-
-  def find_person(self):
-    """
-    Load committee details for the given detail page URL or numeric ID
-    """
-    # Read either person_id or committee_url from the opposite
-    user_overview_url = self.urls['PERSON_OVERVIEW_PRINT_PATTERN'] % self.config['scraper']['base_url']
-    logging.info("Getting user overview from %s", user_overview_url)
-    
-    time.sleep(self.config['scraper']['wait_time'])
-    response = self.get_url(user_overview_url)
-    if not response:
-      return
-    
-    # seek(0) is necessary to reset response pointer.
-    response.seek(0)
-    html = response.read()
-    html = html.replace('&nbsp;', ' ')
-    parser = etree.HTMLParser()
-    dom = etree.parse(StringIO(html), parser)
-    
-    trs = dom.xpath(self.xpath['PERSONLIST_LINES'])
-    for tr in trs:
-      current_person = None
-      link = tr.xpath('.//a')
-      if len(link):
-        parsed = parse.search(self.urls['PERSON_DETAIL_PARSE_PATTERN'], link[0].get('href'))
-        if not parsed:
-          parsed = parse.search(self.urls['PERSON_DETAIL_PARSE_PATTERN_ALT'], link[0].get('href'))
-        if parsed:
-          person_id = parsed['person_id']
-          current_person = Person(originalId=person_id)
-      if current_person:
-        tds = tr.xpath('.//td')
-        if len(tds):
-          if len(tds[0]):
-            person_name = tds[0][0].text.strip()
-            if person_name:
-              current_person.name = person_name
-        if len(tds) > 1:
-          person_party = tds[1].text.strip()
-          if person_party:
-            for party_alias in self.config['scraper']['party_alias']:
-              if party_alias[0] == person_party:
-                person_party = party_alias[1]
-                break
-            new_organization = Organization(originalId=person_party,
-                                            name=person_party,
-                                            classification='party')
-            new_membership = Membership(originalId=unicode(person_id) + '-' + person_party,
-                                        organization=new_organization)
-            current_person.membership = [new_membership]
-        if current_person:
-          if hasattr(self, 'person_queue'):
-            self.person_queue.add(current_person.originalId)
-          self.db.save_person(current_person)
-    return
-
-  """
-  def get_person(self, person_url=None, person_id=None):
-    ""
-    Load committee details for the given detail page URL or numeric ID
-    ""
-    # Read either person_id or committee_url from the opposite
-    if person_id is not None:
-      person_url = self.urls['COMMITTEE_DETAIL_PRINT_PATTERN_FULL'] % person_id
-    elif person_url is not None:
-      parsed = parse.search(self.urls['COMMITTEE_DETAIL_PARSE_PATTERN_FULL'], person_url)
-      person_id = parsed['person_id']
-  
-    logging.info("Getting meeting (committee) %d from %s", person_id, person_url)
-    
-    organisation = Organisation(numeric_id=person_id)
-    
-    time.sleep(self.config['scraper']['wait_time'])
-    response = self.get_url(person_url)
-    if not response:
-      return
-    
-    # seek(0) is necessary to reset response pointer.
-    response.seek(0)
-    html = response.read()
-    html = html.replace('&nbsp;', ' ')
-    parser = etree.HTMLParser()
-    dom = etree.parse(StringIO(html), parser)
-    
-    trs = dom.xpath(self.xpath['COMMITTEE_LINES'])
-    for tr in trs:
-      tds = tr.xpath('.//td')
-      print tds
-      if tr.get('class') == 'smcrowh':
-        print tds[0].text
-      else:
-        for td in tds:
-          print td[0].text
-    return
-  """
-  
-  def get_person_organization(self, person_organization_url=None, person_id=None):
-    """
-    Load committee details for the given detail page URL or numeric ID
-    """
-    # Read either committee_id or committee_url from the opposite
-    if person_id is not None:
-      person_committee_url = self.urls['PERSON_ORGANIZATION_PRINT_PATTERN'] % (self.config['scraper']['base_url'], person_id)
-    elif person_organization_url is not None:
-      parsed = parse.search(self.urls['PERSON_ORGANIZATION_PRINT_PATTERN'], person_organization_url)
-      person_id = parsed['person_id']
-  
-    logging.info("Getting person %d organizations from %s", person_id, person_committee_url)
-    
-    person = Person(originalId=person_id)
-    
-    time.sleep(self.config['scraper']['wait_time'])
-    response = self.get_url(person_committee_url)
-    if not response:
-      return
-    
-    # seek(0) is necessary to reset response pointer.
-    response.seek(0)
-    html = response.read()
-    html = html.replace('&nbsp;', ' ')
-    parser = etree.HTMLParser()
-    dom = etree.parse(StringIO(html), parser)
-    
-    trs = dom.xpath(self.xpath['PERSON_ORGANIZATION_LINES'])
-    organisations = []
-    memberships = []
-    for tr in trs:
-      tds = tr.xpath('.//td')
-      long_info = False
-      if len(tds) == 5:
-        long_info = True
-      if len(tds) == 5 or len(tds) == 2:
-        if tds[0].xpath('.//a'):
-          href = tds[0][0].get('href')
-          href_tmp = href.split('&')
-          # delete __cgrname when it's there
-          if len(href_tmp) == 2:
-            if href_tmp[1][0:10] == '__cgrname=':
-              href = href_tmp[0]
-          parsed = parse.search(self.urls['ORGANIZATION_DETAIL_PARSE_PATTERN'], href)
-          if not parsed:
-            parsed = parse.search(self.urls['ORGANIZATION_DETAIL_PARSE_PATTERN_FULL'], href)
-          if parsed is not None:
-            new_organisation = Organization(originalId=int(parsed['committee_id']))
-            new_organisation.name = tds[0][0].text
-        else:
-          new_organisation = Organization(originalId=tds[0].text)
-        if new_organisation and long_info:
-          new_membership = Membership()
-          membership_original_id = originalId=unicode(person_id) + '-' + unicode(new_organisation.originalId)
-          if tds[2].text:
-            new_membership.role = tds[2].text
-          if tds[3].text:
-            new_membership.startDate = tds[3].text
-            membership_original_id += '-' + tds[3].text
-          if tds[4].text:
-            new_membership.endDate = tds[4].text
-            membership_original_id += '-' + tds[4].text
-          new_membership.originalId = membership_original_id
-          new_membership.organization = new_organisation
-          memberships.append(new_membership)
-        else:
-          if not new_organisation:
-            logging.error("Bad Table Structure in %s", person_committee_url)
-    if memberships:
-      person.membership = memberships
-    oid = self.db.save_person(person)
-    logging.info("Person %d stored with _id %s", person_id, oid)
-    return
-
-  def get_person_committee_presence(self, person_id=None, person_url=None):
-    # URL is like ???
-    # TODO
-    pass
-
-  def find_meeting(self, start_date=None, end_date=None):
-    """
-    Find meetings (sessions) within a given time frame and add them to the session queue.
-    """
-    # list of (year, month) tuples to work from
-    start_month = start_date.month
-    end_months = (end_date.year - start_date.year) * 12 + end_date.month + 1
-    monthlist = [(yr, mn) for (yr, mn) in (
-      ((m - 1) / 12 + start_date.year, (m - 1) % 12 + 1) for m in range(start_month, end_months)
-    )]
-  
-    for (year, month) in monthlist:
-      url = self.urls['CALENDAR_MONTH_PRINT_PATTERN'] % (self.config['scraper']['base_url'], year, month)
-      logging.info("Looking for meetings (sessions) in %04d-%02d at %s", year, month, url)
-      time.sleep(self.config['scraper']['wait_time'])
-      response = self.user_agent.open(url)
-      html = response.read()
-      html = html.replace('&nbsp;', ' ')
-      parser = etree.HTMLParser()
-      dom = etree.parse(StringIO(html), parser)
-      found = 0
-      for link in dom.xpath('//a'):
-        href = link.get('href')
-        if href is None:
-          continue
-        parsed = parse.search(self.urls['MEETING_DETAIL_PARSE_PATTERN'], href)
-        if hasattr(self, 'meeting_queue') and parsed is not None:
-          self.meeting_queue.add(int(parsed['meeting_id']))
-          found += 1
-      if found == 0:
-        logging.info("No meetings(sessions) found for month %04d-%02d", year, month)
-  
-
-  def get_meeting(self, meeting_url=None, meeting_id=None):
-    """
-    Load meeting details for the given detail page URL or numeric ID
-    """
-    # Read either meeting_id or meeting_url from the opposite
-    if meeting_id is not None:
-      meeting_url = self.urls['MEETING_DETAIL_PRINT_PATTERN'] % (self.config["scraper"]["base_url"], meeting_id)
-    elif meeting_url is not None:
-      parsed = parse.search(self.urls['MEETING_DETAIL_PARSE_PATTERN'], meeting_url)
-      meeting_id = parsed['meeting_id']
-  
-    logging.info("Getting meeting (session) %d from %s", meeting_id, meeting_url)
-  
-    meeting = Meeting(originalId=meeting_id)
-    
-    time.sleep(self.config['scraper']['wait_time'])
-    response = self.get_url(meeting_url)
-    if not response:
-      return
-    
-    # forms for later document download
-    mechanize_forms = mechanize.ParseResponse(response, backwards_compat=False)
-    # seek(0) is necessary to reset response pointer.
-    response.seek(0)
-    html = response.read()
-    html = html.replace('&nbsp;', ' ')
-    parser = etree.HTMLParser()
-    dom = etree.parse(StringIO(html), parser)
-    # check for page errors
-    try:
-      page_title = dom.xpath('//h1')[0].text
-      if 'Fehlermeldung' in page_title:
-        logging.info("Page %s cannot be accessed due to server error", meeting_url)
-        return
-      if 'Berechtigungsfehler' in page_title:
-        logging.info("Page %s cannot be accessed due to permissions", meeting_url)
-        return
-    except:
-      pass
-    try:
-      error_h3 = dom.xpath('//h3[@class="smc_h3"]')[0].text.strip()
-      if 'Keine Daten gefunden' in error_h3:
-        logging.info("Page %s does not contain any agenda items", meeting_url)
-        return
-      if 'Fehlercode: 1104' in error_h3:
-        logging.info("Page %s cannot be accessed due to permissions", meeting_url)
-        return
-    except:
-      pass
-  
-    meeting.originalUrl = meeting_url
-    # Session title
-    try:
-      meeting.name = dom.xpath(self.xpath['MEETING_DETAIL_TITLE'])[0].text
-    except:
-      logging.critical('Cannot find session title element using XPath MEETING_DETAIL_TITLE')
-      raise TemplateError('Cannot find session title element using XPath MEETING_DETAIL_TITLE')
-  
-    # Committe link
-    #try:
-    #  links = dom.xpath(self.xpath['MEETING_DETAIL_COMMITTEE_LINK'])
-    #  for link in links:
-    #    href = link.get('href')
-    #    parsed = parse.search(self.urls['COMMITTEE_DETAIL_PARSE_PATTERN'], href)
-    #    if parsed is not None:
-    #      meeting.committees = [Commitee(numeric_id=int(parsed['committee_id']))]
-    #      if hasattr(self, 'committee_queue'):
-    #        self.committee_queue.add(int(parsed['committee_id']))
-    #except:
-    #  logging.critical('Cannot find link to committee detail page using MEETING_DETAIL_COMMITTEE_LINK_XPATH')
-    #  raise TemplateError('Cannot find link to committee detail page using MEETING_DETAIL_COMMITTEE_LINK_XPATH')
-  
-    # Meeting identifier, date, address etc
-    tds = dom.xpath(self.xpath['MEETING_DETAIL_IDENTIFIER_TD'])
-    if len(tds) == 0:
-      logging.critical('Cannot find table fields using MEETING_DETAIL_IDENTIFIER_TD_XPATH at session ' + meeting_url)
-      raise TemplateError('Cannot find table fields using MEETING_DETAIL_IDENTIFIER_TD_XPATH at session ' + meeting_url)
-    else:
-      for n in range(0, len(tds)):
-        try:
-          tdcontent = tds[n].text.strip()
-          nextcontent = tds[n + 1].text.strip()
-        except:
-          continue
-        if tdcontent == 'Sitzung:':
-          meeting.shortName = nextcontent
-        # We don't need this any more because it's scraped in committee detail page(?)
-        #elif tdcontent == 'Gremium:':
-        #  meeting.committee_name = nextcontent
-        elif tdcontent == 'Datum:':
-          start = nextcontent
-          end = nextcontent
-          if tds[n + 2].text == 'Zeit:':
-            if tds[n + 3].text is not None:
-              times = tds[n + 3].text.replace(' Uhr', '').split('-')
-              start = start + ' ' + times[0]
-              if len(times) > 1:
-                end = end + ' ' + times[1]
-              else:
-                end = start
-            meeting.start = start
-            meeting.end = end
-        elif tdcontent == 'Raum:':
-          meeting.address = " ".join(tds[n + 1].xpath('./text()'))
-        elif tdcontent == 'Bezeichnung:':
-          meeting.description = nextcontent
-        # sense?
-        #if not hasattr(meeting, 'originalId'):
-        #  logging.critical('Cannot find session identifier using XPath MEETING_DETAIL_IDENTIFIER_TD')
-        #  raise TemplateError('Cannot find session identifier using XPath MEETING_DETAIL_IDENTIFIER_TD')
-  
-    # Agendaitems
-    found_files = []
-    rows = dom.xpath(self.xpath['MEETING_DETAIL_AGENDAITEM_ROWS'])
-    if len(rows) == 0:
-      no_agendaitem_check = dom.xpath('//h5')
-      no_agendaitem = False
-      for item in no_agendaitem_check:
-        if item.text.strip() == 'Keine Daten gefunden.':
-          no_agendaitem = True
-      if no_agendaitem:
-        logging.warn("Meeting without agendaitems found in %s" % meeting_url)
-      else:
-        logging.critical('Cannot find agenda using XPath MEETING_DETAIL_AGENDAITEM_ROWS at meeting %s' % meeting_url)
-        raise TemplateError('Cannot find agenda using XPath MEETING_DETAIL_AGENDAITEM_ROWS at %s' % meeting_url)
-      meeting.agendaitem = []
-    else:
-      agendaitems = []
-      agendaitem_id = None
-      public = True
-      agendaitem = None
-      for row in rows:
-        row_id = row.get('id')
-        row_classes = row.get('class').split(' ')
-        fields = row.xpath('td')
-        number = fields[0].xpath('./text()')
-        if len(number) > 0:
-          number = number[0]
-        else:
-          # when theres a updated notice theres an additional spam
-          number = fields[0].xpath('.//span/text()')
-          if len(number) > 0:
-            number = number[0]
-        if number == []:
-          number = None
-        if row_id is not None:
-          # Agendaitem main row
-          # first: save agendaitem from before
-          if agendaitem:
-            agendaitems.append(agendaitem)
-          # create new agendaitem
-          agendaitem = AgendaItem(originalId=int(row_id.rsplit('_', 1)[1]))
-          if number is not None:
-            agendaitem.number = number
-          # in some ris this is a link, sometimes not. test both.
-          if len(fields[1].xpath('./a/text()')):
-            agendaitem.name = "; ".join(fields[1].xpath('./a/text()'))
-          elif len(fields[1].xpath('./text()')):
-            agendaitem.name = "; ".join(fields[1].xpath('./text()'))
-          # ignore no agendaitem information
-          if agendaitem.name == 'keine Tagesordnungspunkte':
-            agendaitem = None
-            continue
-          agendaitem.public = public
-          # paper links
-          links = row.xpath(self.xpath['MEETING_DETAIL_AGENDAITEM_ROWS_PAPER_LINK'])
-          consultations = []
-          papers = []
-          for link in links:
-            href = link.get('href')
-            if href is None:
-              continue
-            # links to papers
-            parsed = parse.search(self.urls['PAPER_DETAIL_PARSE_PATTERN'], href)
-            if parsed is not None:
-              consultation = Consultation(originalId=unicode(agendaitem.originalId) + unicode(parsed['paper_id']))
-              consultation.paper = Paper(originalId=int(parsed['paper_id'])) #, name=link.text #TODO: da stehen ab und an Zusatzinfos drin. Wohin damit?
-              consultations.append(consultation)
-              # Add paper to paper queue
-              if hasattr(self, 'paper_queue'):
-                self.paper_queue.add(int(parsed['paper_id']))
-          if len(consultations) == 1:
-            agendaitem.consultation = consultations[0]
-          elif len(consultations) > 1:
-            logging.warn('Multible Papers found in an Agendaitem at %s' % meeting_url)
-          
-          """
-          Note: we don't scrape agendaitem-related documents for now,
-          based on the assumption that they are all found via paper
-          detail pages. All we do here is get a list of document IDs
-          in found_files
-          """
-          # find links
-          links = row.xpath('.//a[contains(@href,"getfile.")]')
-          for link in links:
-            if not link.xpath('.//img'):
-              file_link = self.config['scraper']['base_url'] + link.get('href')
-              file_id = file_link.split('id=')[1].split('&')[0]
-              found_files.append(file_id)
-          # find forms
-          forms = row.xpath('.//form')
-          for form in forms:
-            for hidden_field in form.xpath('input'):
-              if hidden_field.get('name') != 'DT':
-                continue
-              file_id = hidden_field.get('value')
-              found_files.append(file_id)
-        # Alternative für smc_tophz wegen Version 4.3.5 bi (Layout 3)
-        elif ('smc_tophz' in row_classes) or (row.get('valign') == 'top' and row.get('debug') == '3'):
-          # additional (optional row for agendaitem)
-          label = fields[1].text
-          value = fields[2].text
-          if label is not None and value is not None:
-            label = label.strip()
-            value = value.strip()
-            if label in ['Ergebnis:', 'Beschluss:', 'Beratungsergebnis:']:
-              new_result_string = ''
-              for result_string in self.config['scraper']['result_strings']:
-                if result_string[0] == value:
-                  new_result_string = result_string[1]
-                  break
-              if not new_result_string:
-                new_result_string = self.db.save_result_string(value)
-                logging.warn("String '%s' not found in configured RESULT_STRINGS", value)
-              agendaitem.result = new_result_string
-            elif label in ['Bemerkung:', 'Abstimmung:']:
-              agendaitem.result_details = value
-            # What's this?
-            #elif label == 'Abstimmung:':
-            #  agendaitems[agendaitem_id]['voting'] = value
-            else:
-              logging.critical("Agendaitem info label '%s' is unknown", label)
-              raise ValueError('Agendaitem info label "%s" is unknown' % label)
-        elif 'smcrowh' in row_classes:
-          # Subheading (public / nonpublic part)
-          if fields[0].text is not None and "Nicht öffentlich" in fields[0].text.encode('utf-8'):
-            public = False
-      meeting.agendaItem = agendaitems
-
-    # meeting-related documents
-    containers = dom.xpath(self.xpath['MEETING_DETAIL_FILES'])
-    for container in containers:
-      classes = container.get('class')
-      if classes is None:
-        continue
-      classes = classes.split(' ')
-      if self.xpath['MEETING_DETAIL_FILES_CONTAINER_CLASSNAME'] not in classes:
-        continue
-      invitations = []
-      resultsProtocol = None
-      verbatimProtocol = None
-      auxiliaryFile = []
-      rows = container.xpath('.//tr')
-      for row in rows:
-        if not row.xpath('.//form'):
-          links = row.xpath('.//a')
-          for link in links:
-            # ignore additional pdf icon links
-            if not link.xpath('.//img'):
-              name = ' '.join(link.xpath('./text()')).strip()
-              file_link = self.config['scraper']['base_url'] + link.get('href')
-              file_id = file_link.split('id=')[1].split('&')[0]
-              if file_id in found_files:
-                continue
-              file = File(
-                originalId=file_id,
-                name=name,
-                originalUrl=file_link,
-                originalDownloadPossible = True)
-              file = self.get_file(file=file, link=file_link)
-              if 'Einladung' in name:
-                invitations.append(file)
-              elif 'Niederschrift' in name:
-                if resultsProtocol:
-                  logging.warn('Two resultsProtocols found at %s' % meeting_url)
-                else:
-                  resultsProtocol = file
-              else:
-                auxiliaryFile.append(file)
-              found_files.append(file_id)
-        else:
-          forms = row.xpath('.//form')
-          for form in forms:
-            name = " ".join(row.xpath('./td/text()')).strip()
-            for hidden_field in form.xpath('input'):
-              if hidden_field.get('name') != 'DT':
-                continue
-              file_id = hidden_field.get('value')
-              # make sure to add only those which aren't agendaitem-related
-              if file_id not in found_files:
-                file = File(
-                  originalId=file_id,
-                  name=name,
-                  originalDownloadPossible = False
-                )
-                # Traversing the whole mechanize response to submit this form
-                for mform in mechanize_forms:
-                  for control in mform.controls:
-                    if control.name == 'DT' and control.value == file_id:
-                      file = self.get_file(file, mform)
-                if 'Einladung' in name:
-                  invitations.append(file)
-                elif 'Niederschrift' in name:
-                  if resultsProtocol:
-                    logging.warn('Two resultsProtocols found at %s' % meeting_url)
-                  else:
-                    resultsProtocol = file
-                else:
-                  auxiliaryFile.append(file)
-                found_files.append(file_id)
-      if len(invitations):
-        meeting.invitation = invitations
-      if resultsProtocol:
-        meeting.resultsProtocol = resultsProtocol
-      if verbatimProtocol:
-        meeting.verbatimProtocol = verbatimProtocol
-      if len(auxiliaryFile):
-        meeting.auxiliaryFile = auxiliaryFile
-    oid = self.db.save_meeting(meeting)
-    logging.info("Meeting %d stored with _id %s", meeting_id, oid)
+    def guess_system(self):
+        """
+        Tries to find out which SessionNet version we are working with
+        and adapts configuration
+        """
+        time.sleep(self.config['scraper']['wait_time'])
+        # requesting the base URL. This is usually redirected
+        #try:
+        #    response = self.user_agent.open(self.config['scraper']['base_url'])
+        #except urllib2.HTTPError, e:
+        #    if e.code == 404:
+        #        sys.stderr.write("URL not found (HTTP 404) error caught: %s\n"
+        #                         % self.config['scraper']['base_url'])
+        #        sys.stderr.write("Please check BASE_URL in your "
+        #                         "configuration.\n")
+        #        sys.exit(1)
+        #url = response.geturl()
+        #assert (url != self.config['scraper']['base_url']), "No redirect"
+        #if url.endswith('.php'):
+        #    self.template_system = 'php'
+        #elif url.endswith('.asp'):
+        #    self.template_system = 'asp'
+        #else:
+        #    logging.critical("Cannot guess template system from URL '%s'", url)
+        #    sys.stderr.write("CRITICAL ERROR: Cannot guess template system "
+        #                     "from URL '%s'\n" % url)
+        #    # there is no point in going on here.
+        #    sys.exit(1)
+        scraper_type = self.config['scraper']['type']
+        self.urls = self.config['scraper'][scraper_type]['urls']
+        self.xpath = self.config['scraper'][scraper_type]['xpath']
 
 
-  def get_paper(self, paper_url=None, paper_id=None):
-    """
-    Load paper details for the paper given by detail page URL
-    or numeric ID
-    """
-    # Read either paper_id or paper_url from the opposite
-    if paper_id is not None:
-      paper_url = self.urls['PAPER_DETAIL_PRINT_PATTERN'] % (self.config["scraper"]["base_url"], paper_id)
-    elif paper_url is not None:
-      parsed = parse.search(self.urls['PAPER_DETAIL_PARSE_PATTERN'], paper_url)
-      paper_id = parsed['paper_id']
-  
-    logging.info("Getting paper %d from %s", paper_id, paper_url)
-    
-    paper = Paper(originalId=paper_id)
-    try_until = 1
-    try_counter = 0
-    try_found = False
-    
-    while (try_counter < try_until):
-      try_counter += 1
-      try_found = False
-      time.sleep(self.config['scraper']['wait_time'])
-      try:
-        response = self.user_agent.open(paper_url)
-      except urllib2.HTTPError, e:
-        if e.code == 404:
-          sys.stderr.write("URL not found (HTTP 404) error caught: %s\n" % paper_url)
-          sys.stderr.write("Please check BASE_URL in your configuration.\n")
-          sys.exit(1)
-        elif e.code == 502 or e.code == 500:
-          try_until = 4
-          try_found = True
-          if try_until == try_counter:
-            logging.error("Permanent error in %s after 4 retrys.", paper_url)
+    def find_person(self):
+        """ Load committee details for the given detail page URL or numeric ID
+        """
+        # Read either person_id or committee_url from the opposite
+        user_overview_url = (self.urls['PERSON_OVERVIEW_PRINT_PATTERN']
+                             % self.config['scraper']['base_url'])
+        logging.info("Getting user overview from %s", user_overview_url)
+
+        time.sleep(self.config['scraper']['wait_time'])
+        response = self.get_url(user_overview_url)
+        if not response:
             return
-          else:
-            logging.info("Original RIS Server Bug, restart fetching paper %s", paper_url)
-      if not response:
+
+        # seek(0) is necessary to reset response pointer.
+        response.seek(0)
+        html = response.read()
+        html = html.replace('&nbsp;', ' ')
+        parser = etree.HTMLParser()
+        dom = etree.parse(StringIO(html), parser)
+
+        trs = dom.xpath(self.xpath['PERSONLIST_LINES'])
+        for tr in trs:
+            current_person = None
+            link = tr.xpath('.//a')
+            if len(link):
+                parsed = parse.search(self.urls['PERSON_DETAIL_PARSE_PATTERN'],
+                                      link[0].get('href'))
+                if not parsed:
+                    parsed = parse.search(
+                        self.urls['PERSON_DETAIL_PARSE_PATTERN_ALT'],
+                        link[0].get('href'))
+                if parsed:
+                    person_id = parsed['person_id']
+                    current_person = Person(originalId=person_id)
+            if current_person:
+                tds = tr.xpath('.//td')
+                if len(tds):
+                    if len(tds[0]):
+                        person_name = tds[0][0].text.strip()
+                        if person_name:
+                            current_person.name = person_name
+                if len(tds) > 1:
+                    person_party = tds[1].text.strip()
+                    if person_party:
+                        for party_alias in self.config['scraper']\
+                                           ['party_alias']:
+                            if party_alias[0] == person_party:
+                                person_party = party_alias[1]
+                                break
+                        new_organization = Organization(originalId=person_party,
+                                                        name=person_party,
+                                                        classification='party')
+                        original_id = "%s-%s" % (person_id, person_party)
+                        new_membership = Membership(
+                            originalId=original_id,
+                            organization=new_organization)
+                        current_person.membership = [new_membership]
+                if current_person:
+                    if hasattr(self, 'person_queue'):
+                        self.person_queue.add(current_person.originalId)
+                    self.db.save_person(current_person)
         return
-      mechanize_forms = mechanize.ParseResponse(response, backwards_compat=False)
-      response.seek(0)
-      html = response.read()
-      html = html.replace('&nbsp;', ' ')
-      parser = etree.HTMLParser()
-      dom = etree.parse(StringIO(html), parser)
-      # Hole die Seite noch einmal wenn unbekannter zufällig auftretender Fehler ohne Fehlermeldung ausgegeben wird (gefunden in Duisburg, vermutlich kaputte Server Config)
-      try:
-        page_title = dom.xpath('//h1')[0].text
-        if 'Fehler' in page_title:
-          try_until = 4
-          try_found = True
-          if try_until == try_counter:
-            logging.error("Permanent error in %s after 3 retrys, proceed.", paper_url)
-          else:
-            logging.info("Original RIS Server Bug, restart scraping paper %s", paper_url)
-      except:
+
+    """
+    def get_person(self, person_url=None, person_id=None):
+        ""
+        Load committee details for the given detail page URL or numeric ID
+        ""
+        # Read either person_id or committee_url from the opposite
+        if person_id is not None:
+            person_url = (self.urls['COMMITTEE_DETAIL_PRINT_PATTERN_FULL']
+                          % person_id)
+        elif person_url is not None:
+            parsed = parse.search(
+                self.urls['COMMITTEE_DETAIL_PARSE_PATTERN_FULL'], person_url)
+            person_id = parsed['person_id']
+
+        logging.info("Getting meeting (committee) %d from %s",
+                     person_id, person_url)
+
+        organisation = Organisation(numeric_id=person_id)
+
+        time.sleep(self.config['scraper']['wait_time'])
+        response = self.get_url(person_url)
+        if not response:
+            return
+
+        # seek(0) is necessary to reset response pointer.
+        response.seek(0)
+        html = response.read()
+        html = html.replace('&nbsp;', ' ')
+        parser = etree.HTMLParser()
+        dom = etree.parse(StringIO(html), parser)
+
+        trs = dom.xpath(self.xpath['COMMITTEE_LINES'])
+        for tr in trs:
+            tds = tr.xpath('.//td')
+            print tds
+            if tr.get('class') == 'smcrowh':
+                print tds[0].text
+            else:
+                for td in tds:
+                    print td[0].text
+        return
+    """
+
+    def get_person_organization(self, person_organization_url=None,
+                                person_id=None):
+        """ Load committee details for the given detail page URL or numeric ID
+        """
+        # Read either committee_id or committee_url from the opposite
+        if person_id is not None:
+            person_committee_url = (self.urls['PERSON_ORGANIZATION_PRINT_PATTERN']
+                                    % (self.config['scraper']['base_url'],
+                                       person_id))
+        elif person_organization_url is not None:
+            parsed = parse.search(self.urls['PERSON_ORGANIZATION_PRINT_PATTERN'],
+                                  person_organization_url)
+            person_id = parsed['person_id']
+
+        logging.info("Getting person %d organizations from %s",
+                     person_id, person_committee_url)
+
+        person = Person(originalId=person_id)
+
+        time.sleep(self.config['scraper']['wait_time'])
+        response = self.get_url(person_committee_url)
+        if not response:
+            return
+
+        # seek(0) is necessary to reset response pointer.
+        response.seek(0)
+        html = response.read()
+        html = html.replace('&nbsp;', ' ')
+        parser = etree.HTMLParser()
+        dom = etree.parse(StringIO(html), parser)
+
+        trs = dom.xpath(self.xpath['PERSON_ORGANIZATION_LINES'])
+        memberships = []
+        for tr in trs:
+            tds = tr.xpath('.//td')
+            long_info = False
+            if len(tds) == 5:
+                long_info = True
+            if len(tds) == 5 or len(tds) == 2:
+                if tds[0].xpath('.//a'):
+                    href = tds[0][0].get('href')
+                    href_tmp = href.split('&')
+                    # delete __cgrname when it's there
+                    if len(href_tmp) == 2:
+                        if href_tmp[1][0:10] == '__cgrname=':
+                            href = href_tmp[0]
+                    parsed = parse.search(
+                        self.urls['ORGANIZATION_DETAIL_PARSE_PATTERN'], href)
+                    if not parsed:
+                        parsed = parse.search(
+                            self.urls['ORGANIZATION_DETAIL_PARSE_PATTERN_FULL'],
+                            href)
+                    if parsed is not None:
+                        original_id = int(parsed['committee_id'])
+                        new_organisation = Organization(originalId=original_id)
+                        new_organisation.name = tds[0][0].text
+                else:
+                    new_organisation = Organization(originalId=tds[0].text)
+                if new_organisation and long_info:
+                    new_membership = Membership()
+                    membership_original_id = ("%s-%s"
+                                              % (person_id,
+                                                 new_organisation.originalId))
+                    if tds[2].text:
+                        new_membership.role = tds[2].text
+                    if tds[3].text:
+                        new_membership.startDate = tds[3].text
+                        membership_original_id += '-' + tds[3].text
+                    if tds[4].text:
+                        new_membership.endDate = tds[4].text
+                        membership_original_id += '-' + tds[4].text
+                    new_membership.originalId = membership_original_id
+                    new_membership.organization = new_organisation
+                    memberships.append(new_membership)
+                else:
+                    if not new_organisation:
+                        logging.error("Bad Table Structure in %s",
+                                      person_committee_url)
+        if memberships:
+            person.membership = memberships
+        oid = self.db.save_person(person)
+        logging.info("Person %d stored with _id %s", person_id, oid)
+        return
+
+    def get_person_committee_presence(self, person_id=None, person_url=None):
+        # URL is like ???
+        # TODO
         pass
-      if (try_found == False):
+
+    def find_meeting(self, start_date=None, end_date=None):
+        """ Find meetings (sessions) within a given time frame and add
+        them to the session queue.
+        """
+        # list of (year, month) tuples to work from
+        start_month = start_date.month
+        end_months = (end_date.year - start_date.year) * 12 + end_date.month + 1
+        monthlist = [(yr, mn) for (yr, mn) in (
+            ((m - 1) / 12 + start_date.year, (m - 1) % 12 + 1)
+            for m in range(start_month, end_months)
+        )]
+
+        for (year, month) in monthlist:
+            url = (self.urls['CALENDAR_MONTH_PRINT_PATTERN']
+                   % (self.config['scraper']['base_url'], year, month))
+            logging.info("Looking for meetings (sessions) in %04d-%02d at %s",
+                         year, month, url)
+            time.sleep(self.config['scraper']['wait_time'])
+            response = self.user_agent.open(url)
+            html = response.read()
+            html = html.replace('&nbsp;', ' ')
+            parser = etree.HTMLParser()
+            dom = etree.parse(StringIO(html), parser)
+            found = 0
+            for link in dom.xpath('//a'):
+                href = link.get('href')
+                if href is None:
+                    continue
+                parsed = parse.search(self.urls['MEETING_DETAIL_PARSE_PATTERN'],
+                                      href)
+                if hasattr(self, 'meeting_queue') and parsed is not None:
+                    self.meeting_queue.add(int(parsed['meeting_id']))
+                    found += 1
+            if found == 0:
+                logging.info("No meetings(sessions) found for month %04d-%02d",
+                             year, month)
+
+
+    def get_meeting(self, meeting_url=None, meeting_id=None):
+        """ Load meeting details for the given detail page URL or numeric ID
+        """
+        # Read either meeting_id or meeting_url from the opposite
+        if meeting_id is not None:
+            meeting_url = (self.urls['MEETING_DETAIL_PRINT_PATTERN']
+                           % (self.config["scraper"]["base_url"], meeting_id))
+        elif meeting_url is not None:
+            parsed = parse.search(self.urls['MEETING_DETAIL_PARSE_PATTERN'],
+                                  meeting_url)
+            meeting_id = parsed['meeting_id']
+
+        logging.info("Getting meeting (session) %d from %s",
+                     meeting_id, meeting_url)
+
+        meeting = Meeting(originalId=meeting_id)
+
+        time.sleep(self.config['scraper']['wait_time'])
+        response = self.get_url(meeting_url)
+        if not response:
+            return
+
+        # forms for later document download
+        mechanize_forms = mechanize.ParseResponse(response,
+                                                  backwards_compat=False)
+        # seek(0) is necessary to reset response pointer.
+        response.seek(0)
+        html = response.read()
+        html = html.replace('&nbsp;', ' ')
+        parser = etree.HTMLParser()
+        dom = etree.parse(StringIO(html), parser)
         # check for page errors
         try:
-          if 'Fehlermeldung' in page_title:
-            logging.info("Page %s cannot be accessed due to server error", paper_url)
-            return
-          if 'Berechtigungsfehler' in page_title:
-            logging.info("Page %s cannot be accessed due to permissions", paper_url)
-            return
+            page_title = dom.xpath('//h1')[0].text
+            if 'Fehlermeldung' in page_title:
+                logging.info("Page %s cannot be accessed due to server error",
+                             meeting_url)
+                return
+            if 'Berechtigungsfehler' in page_title:
+                logging.info("Page %s cannot be accessed due to permissions",
+                             meeting_url)
+                return
         except:
-          pass
-    
-        paper.originalUrl = paper_url
-        superordinated_papers = []
-        subordinated_papers = []
-        
-        # Paper title
+            pass
         try:
-          stitle = dom.xpath(self.xpath['PAPER_DETAIL_TITLE'])
-          paper.title = stitle[0].text
+            error_h3 = dom.xpath('//h3[@class="smc_h3"]')[0].text.strip()
+            if 'Keine Daten gefunden' in error_h3:
+                logging.info("Page %s does not contain any agenda items",
+                             meeting_url)
+                return
+            if 'Fehlercode: 1104' in error_h3:
+                logging.info("Page %s cannot be accessed due to permissions",
+                             meeting_url)
+                return
         except:
-          logging.critical('Cannot find paper title element using XPath PAPER_DETAIL_TITLE')
-          raise TemplateError('Cannot find paper title element using XPath PAPER_DETAIL_TITLE')
-      
-        # Paper identifier, date, type etc
-        tds = dom.xpath(self.xpath['PAPER_DETAIL_IDENTIFIER_TD'])
+            pass
+
+        meeting.originalUrl = meeting_url
+        # Session title
+        try:
+            meeting.name = dom.xpath(self.xpath['MEETING_DETAIL_TITLE'])[0].text
+        except:
+            logging.critical('Cannot find session title element using XPath '
+                             'MEETING_DETAIL_TITLE')
+            raise TemplateError('Cannot find session title element using XPath '
+                                'MEETING_DETAIL_TITLE')
+
+        # Committe link
+        #try:
+        #    links = dom.xpath(self.xpath['MEETING_DETAIL_COMMITTEE_LINK'])
+        #    for link in links:
+        #        href = link.get('href')
+        #        parsed = parse.search(
+        #            self.urls['COMMITTEE_DETAIL_PARSE_PATTERN'], href)
+        #        if parsed is not None:
+        #            meeting.committees = [Commitee(numeric_id=int(
+        #                parsed['committee_id']))]
+        #            if hasattr(self, 'committee_queue'):
+        #                self.committee_queue.add(int(parsed['committee_id']))
+        #except:
+        #    logging.critical('Cannot find link to committee detail page using '
+        #                     'MEETING_DETAIL_COMMITTEE_LINK_XPATH')
+        #    raise TemplateError('Cannot find link to committee detail page '
+        #                        'using MEETING_DETAIL_COMMITTEE_LINK_XPATH')
+
+        # Meeting identifier, date, address etc
+        tds = dom.xpath(self.xpath['MEETING_DETAIL_IDENTIFIER_TD'])
         if len(tds) == 0:
-          logging.critical('Cannot find table fields using XPath PAPER_DETAIL_IDENTIFIER_TD')
-          logging.critical('HTML Dump:' + html)
-          raise TemplateError('Cannot find table fields using XPath PAPER_DETAIL_IDENTIFIER_TD')
+            logging.critical('Cannot find table fields using '
+                             'MEETING_DETAIL_IDENTIFIER_TD_XPATH at session %s',
+                             meeting_url)
+            raise TemplateError('Cannot find table fields using '
+                                'MEETING_DETAIL_IDENTIFIER_TD_XPATH at session '
+                                + meeting_url)
         else:
-          current_category = None
-          for n in range(0, len(tds)):
-            try:
-              tdcontent = tds[n].text.strip()
-            except:
-              continue
-            if tdcontent == 'Name:':
-              paper.nameShort = tds[n + 1].text.strip()
-            # TODO: Dereferenzierung von Paper Type Strings
-            elif tdcontent == 'Art:':
-              paper.paperType = tds[n + 1].text.strip()
-            elif tdcontent == 'Datum:':
-              paper.publishedDate = tds[n + 1].text.strip()
-            elif tdcontent == 'Betreff:':
-              paper.name = '; '.join(tds[n + 1].xpath('./text()'))
-            elif tdcontent == 'Aktenzeichen:':
-              paper.reference = tds[n + 1].text.strip()
-            elif tdcontent == 'Referenzvorlage:':
-              link = tds[n + 1].xpath('a')[0]
-              href = link.get('href')
-              parsed = parse.search(self.urls['PAPER_DETAIL_PARSE_PATTERN'], href)
-              superordinated_paper = Paper(originalId=parsed['paper_id'], nameShort=link.text.strip())
-              superordinated_papers.append(superordinated_paper)
-              # add superordinate paper to queue
-              if hasattr(self, 'paper_queue'):
-                self.paper_queue.add(parsed['paper_id'])
-            # subordinate papers are added to the queue
-            elif tdcontent == 'Untergeordnete Vorlage(n):':
-              current_category = 'subordinates'
-              for link in tds[n + 1].xpath('a'):
-                href = link.get('href')
-                parsed = parse.search(self.urls['PAPER_DETAIL_PARSE_PATTERN'], href)
-                subordinated_paper = Paper(originalId=parsed['paper_id'], nameShort=link.text.strip())
-                subordinated_papers.append(subordinated_paper)
-                if hasattr(self, 'paper_queue') and parsed is not None:
-                  # add subordinate paper to queue
-                  self.paper_queue.add(parsed['paper_id'])
-            elif tdcontent == u'Anträge zur Vorlage:':
-              current_category = 'todo'
-              pass #TODO: WTF is this?
+            for n in range(0, len(tds)):
+                try:
+                    tdcontent = tds[n].text.strip()
+                    nextcontent = tds[n + 1].text.strip()
+                except:
+                    continue
+                if tdcontent == 'Sitzung:':
+                    meeting.shortName = nextcontent
+                # We don't need this any more because it's scraped in
+                # committee detail page(?).
+                #elif tdcontent == 'Gremium:':
+                #    meeting.committee_name = nextcontent
+                elif tdcontent == 'Datum:':
+                    start = nextcontent
+                    end = nextcontent
+                    if tds[n + 2].text == 'Zeit:':
+                        if tds[n + 3].text is not None:
+                            times = tds[n + 3].text.replace(
+                                ' Uhr', '').split('-')
+                            start = start + ' ' + times[0]
+                            if len(times) > 1:
+                                end = end + ' ' + times[1]
+                            else:
+                                end = start
+                        meeting.start = start
+                        meeting.end = end
+                elif tdcontent == 'Raum:':
+                    meeting.address = " ".join(tds[n + 1].xpath('./text()'))
+                elif tdcontent == 'Bezeichnung:':
+                    meeting.description = nextcontent
+                # sense?
+                #if not hasattr(meeting, 'originalId'):
+                #    logging.critical('Cannot find session identifier using '
+                #                     'XPath MEETING_DETAIL_IDENTIFIER_TD')
+                #    raise TemplateError('Cannot find session identifier using '
+                #                        'XPath MEETING_DETAIL_IDENTIFIER_TD')
+
+        # Agendaitems
+        found_files = []
+        rows = dom.xpath(self.xpath['MEETING_DETAIL_AGENDAITEM_ROWS'])
+        if len(rows) == 0:
+            no_agendaitem_check = dom.xpath('//h5')
+            no_agendaitem = False
+            for item in no_agendaitem_check:
+                if item.text.strip() == 'Keine Daten gefunden.':
+                    no_agendaitem = True
+            if no_agendaitem:
+                logging.warn("Meeting without agendaitems found in %s",
+                             meeting_url)
             else:
-              if current_category == 'subordinates' and len(tds) > n+1:
-                for link in tds[n + 1].xpath('a'):
-                  href = link.get('href')
-                  parsed = parse.search(self.urls['PAPER_DETAIL_PARSE_PATTERN'], href)
-                  subordinated_paper = Paper(originalId=parsed['paper_id'], nameShort=link.text.strip())
-                  subordinated_papers.append(subordinated_paper)
-                  if hasattr(self, 'paper_queue') and parsed is not None:
-                    self.paper_queue.add(parsed['paper_id'])
-          if len(subordinated_papers):
-            paper.subordinatedPaper = subordinated_papers
-          if len(superordinated_papers):
-            paper.superordinatedPaper = superordinated_papers
-          if not hasattr(paper, 'originalId'):
-            logging.critical('Cannot find paper identifier using MEETING_DETAIL_IDENTIFIER_TD')
-            raise TemplateError('Cannot find paper identifier using MEETING_DETAIL_IDENTIFIER_TD')
-      
-        # "Beratungsfolge"(list of sessions for this paper)
-        # This is currently not parsed for scraping, but only for
-        # gathering session-document ids for later exclusion
-        found_files = [] #already changed: found_files, files. todo: document_foo
-        rows = dom.xpath(self.xpath['PAPER_DETAIL_AGENDA_ROWS'])
-        for row in rows:
-          # find forms
-          formfields = row.xpath('.//input[@type="hidden"][@name="DT"]')
-          for formfield in formfields:
-            file_id = formfield.get('value')
-            if file_id is not None:
-              found_files.append(file_id)
-          # find links
-          links = row.xpath('.//a[contains(@href,"getfile.")]')
-          for link in links:
-            if not link.xpath('.//img'):
-              file_link = self.config['scraper']['base_url'] + link.get('href')
-              file_id = file_link.split('id=')[1].split('&')[0]
-              found_files.append(file_id)
-        # paper-related documents
-        files = []
-        containers = dom.xpath(self.xpath['PAPER_DETAIL_FILES'])
+                logging.critical('Cannot find agenda using XPath '
+                                 'MEETING_DETAIL_AGENDAITEM_ROWS at meeting %s',
+                                 meeting_url)
+                raise TemplateError('Cannot find agenda using XPath '
+                                    'MEETING_DETAIL_AGENDAITEM_ROWS at %s'
+                                    % meeting_url)
+            meeting.agendaitem = []
+        else:
+            agendaitems = []
+            public = True
+            agendaitem = None
+            for row in rows:
+                row_id = row.get('id')
+                row_classes = row.get('class').split(' ')
+                fields = row.xpath('td')
+                number = fields[0].xpath('./text()')
+                if len(number) > 0:
+                    number = number[0]
+                else:
+                    # when theres a updated notice theres an additional spam
+                    number = fields[0].xpath('.//span/text()')
+                    if len(number) > 0:
+                        number = number[0]
+                if number == []:
+                    number = None
+                if row_id is not None:
+                    # Agendaitem main row
+                    # first: save agendaitem from before
+                    if agendaitem:
+                        agendaitems.append(agendaitem)
+                    # create new agendaitem
+                    agendaitem = AgendaItem(originalId=int(row_id.rsplit('_', 1)[1]))
+                    if number is not None:
+                        agendaitem.number = number
+                    # in some ris this is a link, sometimes not. test both.
+                    if len(fields[1].xpath('./a/text()')):
+                        agendaitem.name = "; ".join(fields[1].xpath('./a/text()'))
+                    elif len(fields[1].xpath('./text()')):
+                        agendaitem.name = "; ".join(fields[1].xpath('./text()'))
+                    # ignore no agendaitem information
+                    if agendaitem.name == 'keine Tagesordnungspunkte':
+                        agendaitem = None
+                        continue
+                    agendaitem.public = public
+                    # paper links
+                    links = row.xpath(
+                        self.xpath['MEETING_DETAIL_AGENDAITEM_ROWS_PAPER_LINK'])
+                    consultations = []
+                    for link in links:
+                        href = link.get('href')
+                        if href is None:
+                            continue
+                        # links to papers
+                        parsed = parse.search(
+                            self.urls['PAPER_DETAIL_PARSE_PATTERN'], href)
+                        if parsed is not None:
+                            original_id = (unicode(agendaitem.originalId)
+                                           + unicode(parsed['paper_id']))
+                            consultation = Consultation(originalId=original_id)
+                            # TODO: da stehen ab und an Zusatzinfos drin.
+                            #       Wohin damit?
+                            # additional paramter? name=link.text
+                            consultation.paper = Paper(
+                                originalId=int(parsed['paper_id']))
+                            consultations.append(consultation)
+                            # Add paper to paper queue
+                            if hasattr(self, 'paper_queue'):
+                                self.paper_queue.add(int(parsed['paper_id']))
+                    if len(consultations) == 1:
+                        agendaitem.consultation = consultations[0]
+                    elif len(consultations) > 1:
+                        logging.warn('Multible Papers found in an Agendaitem '
+                                     'at %s', meeting_url)
+
+                    """
+                    Note: we don't scrape agendaitem-related documents for now,
+                    based on the assumption that they are all found via paper
+                    detail pages. All we do here is get a list of document IDs
+                    in found_files
+                    """
+                    # find links
+                    links = row.xpath('.//a[contains(@href,"getfile.")]')
+                    for link in links:
+                        if not link.xpath('.//img'):
+                            file_link = (self.config['scraper']['base_url']
+                                         + link.get('href'))
+                            file_id = file_link.split('id=')[1].split('&')[0]
+                            found_files.append(file_id)
+                    # find forms
+                    forms = row.xpath('.//form')
+                    for form in forms:
+                        for hidden_field in form.xpath('input'):
+                            if hidden_field.get('name') != 'DT':
+                                continue
+                            file_id = hidden_field.get('value')
+                            found_files.append(file_id)
+                # Alternative für smc_tophz wegen Version 4.3.5 bi (Layout 3)
+                elif (('smc_tophz' in row_classes)
+                      or ((row.get('valign') == 'top')
+                          and (row.get('debug') == '3'))):
+                    # additional (optional row for agendaitem)
+                    label = fields[1].text
+                    value = fields[2].text
+                    if label is not None and value is not None:
+                        label = label.strip()
+                        value = value.strip()
+                        if label in ['Ergebnis:', 'Beschluss:',
+                                     'Beratungsergebnis:']:
+                            new_result_string = ''
+                            for result_string in self.config['scraper'][
+                                    'result_strings']:
+                                if result_string[0] == value:
+                                    new_result_string = result_string[1]
+                                    break
+                            if not new_result_string:
+                                new_result_string = self.db.save_result_string(value)
+                                logging.warn("String '%s' not found in "
+                                             "configured RESULT_STRINGS",
+                                             value)
+                            agendaitem.result = new_result_string
+                        elif label in ['Bemerkung:', 'Abstimmung:']:
+                            agendaitem.result_details = value
+                        # What's this?
+                        #elif label == 'Abstimmung:':
+                        #    agendaitems[agendaitem_id]['voting'] = value
+                        else:
+                            logging.critical("Agendaitem info label '%s' "
+                                             "is unknown", label)
+                            raise ValueError("Agendaitem info label '%s' "
+                                             "is unknown" % label)
+                elif 'smcrowh' in row_classes:
+                    # Subheading (public / nonpublic part)
+                    text = fields[0].text
+                    if ((text is not None)
+                            and ("Nicht öffentlich" in text.encode('utf-8'))):
+                        public = False
+            meeting.agendaItem = agendaitems
+
+        # meeting-related documents
+        containers = dom.xpath(self.xpath['MEETING_DETAIL_FILES'])
         for container in containers:
-          try:
-            classes = container.get('class').split(' ')
-          except:
-            continue
-          if self.xpath['PAPER_DETAIL_FILES_CONTAINER_CLASSNAME'] not in classes:
-            continue
-          rows = container.xpath('.//tr')
-          for row in rows:
-            # seems that we have direct links
-            if not row.xpath('.//form'):
-              links = row.xpath('.//a')
-              for link in links:
-                # ignore additional pdf icon links
-                if not link.xpath('.//img'):
-                  name = ' '.join(link.xpath('./text()')).strip()
-                  file_link = self.config['scraper']['base_url'] + link.get('href')
-                  file_id = file_link.split('id=')[1].split('&')[0]
-                  if file_id in found_files:
-                    continue
-                  file = File(
-                    originalId=file_id,
-                    name=name,
-                    originalUrl=file_link,
-                    originalDownloadPossible = True)
-                  file = self.get_file(file=file, link=file_link)
-                  files.append(file)
-                  found_files.append(file_id)
-                  
-            # no direct link, so we have to handle forms
-            else:
-              forms = row.xpath('.//form')
-              for form in forms:
-                name = " ".join(row.xpath('./td/text()')).strip()
-                for hidden_field in form.xpath('input[@name="DT"]'):
-                  file_id = hidden_field.get('value')
-                  if file_id in found_files:
-                    continue
-                  file = File(
-                    originalId=file_id,
-                    name=name,
-                    originalDownloadPossible = False)
-                  # Traversing the whole mechanize response to submit this form
-                  for mform in mechanize_forms:
-                    for control in mform.controls:
-                      if control.name == 'DT' and control.value == file_id:
-                        file = self.get_file(file=file, form=mform)
-                        files.append(file)
-                        found_files.append(file_id)
-        if len(files):
-          paper.mainFile = files[0]
-        if len(files) > 1:
-          paper.auxiliaryFile = files[1:]
-        oid = self.db.save_paper(paper)
+            classes = container.get('class')
+            if classes is None:
+                continue
+            classes = classes.split(' ')
+            if (self.xpath['MEETING_DETAIL_FILES_CONTAINER_CLASSNAME']
+                    not in classes):
+                continue
+            invitations = []
+            resultsProtocol = None
+            verbatimProtocol = None
+            auxiliaryFile = []
+            rows = container.xpath('.//tr')
+            for row in rows:
+                if not row.xpath('.//form'):
+                    links = row.xpath('.//a')
+                    for link in links:
+                        # ignore additional pdf icon links
+                        if not link.xpath('.//img'):
+                            name = ' '.join(link.xpath('./text()')).strip()
+                            file_link = (self.config['scraper']['base_url']
+                                         + link.get('href'))
+                            file_id = file_link.split('id=')[1].split('&')[0]
+                            if file_id in found_files:
+                                continue
+                            file_obj = File(
+                                originalId=file_id,
+                                name=name,
+                                originalUrl=file_link,
+                                originalDownloadPossible=True)
+                            file_obj = self.get_file(file_obj,
+                                                     link=file_link)
+                            if 'Einladung' in name:
+                                invitations.append(file_obj)
+                            elif 'Niederschrift' in name:
+                                if resultsProtocol:
+                                    logging.warn('Two resultsProtocols found '
+                                                 'at %s', meeting_url)
+                                else:
+                                    resultsProtocol = file_obj
+                            else:
+                                auxiliaryFile.append(file_obj)
+                            found_files.append(file_id)
+                else:
+                    forms = row.xpath('.//form')
+                    for form in forms:
+                        name = " ".join(row.xpath('./td/text()')).strip()
+                        for hidden_field in form.xpath('input'):
+                            if hidden_field.get('name') != 'DT':
+                                continue
+                            file_id = hidden_field.get('value')
+                            # Make sure to add only those which aren't
+                            # agendaitem-related.
+                            if file_id not in found_files:
+                                file_obj = File(
+                                    originalId=file_id,
+                                    name=name,
+                                    originalDownloadPossible=False
+                                )
+                                # Traversing the whole mechanize response
+                                # to submit this form.
+                                for mform in mechanize_forms:
+                                    for control in mform.controls:
+                                        if ((control.name == 'DT')
+                                                and (control.value == file_id)):
+                                            file_obj = self.get_file(file_obj,
+                                                                     mform)
+                                if 'Einladung' in name:
+                                    invitations.append(file)
+                                elif 'Niederschrift' in name:
+                                    if resultsProtocol:
+                                        logging.warn('Two resultsProtocols '
+                                                     'found at %s', meeting_url)
+                                    else:
+                                        resultsProtocol = file_obj
+                                else:
+                                    auxiliaryFile.append(file_obj)
+                                found_files.append(file_id)
+            if invitations:
+                meeting.invitation = invitations
+            if resultsProtocol:
+                meeting.resultsProtocol = resultsProtocol
+            if verbatimProtocol:
+                meeting.verbatimProtocol = verbatimProtocol
+            if auxiliaryFile:
+                meeting.auxiliaryFile = auxiliaryFile
+        oid = self.db.save_meeting(meeting)
+        logging.info("Meeting %d stored with _id %s", meeting_id, oid)
 
-  def get_file(self, file, form=None, link=None):
-    """
-    Loads the file from the server and stores it into
-    the file object given as a parameter. The form
-    parameter is the mechanize Form to be submitted for downloading
-    the file.
-  
-    The file parameter has to be an object of type
-    model.file.File.
-    """
-    logging.info("Getting file '%s'", file.originalId)
-    if form:
-      mechanize_request = form.click()
-    elif link:
-      mechanize_request = mechanize.Request(link)
-    else:
-      logging.warn("No form or link provided")
-      
-    retry_counter = 0
-    while retry_counter < 4:
-      retry = False
-      try:
-        mform_response = mechanize.urlopen(mechanize_request)
-        retry_counter = 4
-        mform_url = mform_response.geturl()
-        if not self.list_in_string(self.urls['FILE_DOWNLOAD_TARGET'], mform_url) and form:
-          logging.warn("Unexpected form target URL '%s'", mform_url)
-          return file
-        file.content = mform_response.read()
-        if ord(file.content[0]) == 32 and ord(file.content[1]) == 10:
-          file.content = file.content[2:]
-        file.mimetype = magic.from_buffer(file.content, mime=True)
-        file.filename = self.make_filename(file)
-      except mechanize.HTTPError as e:
-        if e.code == 502 or e.code == 500:
-          retry_counter = retry_counter + 1
-          retry = True
-          logging.info("HTTP Error %s while getting %s, try again" % (e.code, link))
-          time.sleep(self.config['scraper']['wait_time'] * 5)
+
+    def get_paper(self, paper_url=None, paper_id=None):
+        """
+        Load paper details for the paper given by detail page URL
+        or numeric ID
+        """
+        # Read either paper_id or paper_url from the opposite
+        if paper_id is not None:
+            paper_url = (self.urls['PAPER_DETAIL_PRINT_PATTERN']
+                         % (self.config["scraper"]["base_url"], paper_id))
+        elif paper_url is not None:
+            parsed = parse.search(self.urls['PAPER_DETAIL_PARSE_PATTERN'],
+                                  paper_url)
+            paper_id = parsed['paper_id']
+
+        logging.info("Getting paper %d from %s", paper_id, paper_url)
+
+        paper = Paper(originalId=paper_id)
+        try_until = 1
+        try_counter = 0
+        try_found = False
+
+        while try_counter < try_until:
+            try_counter += 1
+            try_found = False
+            time.sleep(self.config['scraper']['wait_time'])
+            try:
+                response = self.user_agent.open(paper_url)
+            except urllib2.HTTPError, e:
+                if e.code == 404:
+                    sys.stderr.write("URL not found (HTTP 404) error "
+                                     "caught: %s\n" % paper_url)
+                    sys.stderr.write("Please check BASE_URL in your "
+                                     "configuration.\n")
+                    sys.exit(1)
+                elif e.code in (500, 502):
+                    try_until = 4
+                    try_found = True
+                    if try_until == try_counter:
+                        logging.error("Permanent error in %s after %d retrys.",
+                                      paper_url, try_counter)
+                        return
+                    else:
+                        logging.info("Original RIS Server Bug, restart "
+                                     "fetching paper %s", paper_url)
+            if not response:
+                return
+            mechanize_forms = mechanize.ParseResponse(response,
+                                                      backwards_compat=False)
+            response.seek(0)
+            html = response.read()
+            html = html.replace('&nbsp;', ' ')
+            parser = etree.HTMLParser()
+            dom = etree.parse(StringIO(html), parser)
+            # Hole die Seite noch einmal wenn unbekannter zufällig
+            # auftretender Fehler ohne Fehlermeldung ausgegeben wird
+            # (gefunden in Duisburg, vermutlich kaputte Server Config).
+            try:
+                page_title = dom.xpath('//h1')[0].text
+                if 'Fehler' in page_title:
+                    try_until = 4
+                    try_found = True
+                    if try_until == try_counter:
+                        logging.error("Permanent error in %s after %d retrys, "
+                                      "proceed.", paper_url, try_counter)
+                    else:
+                        logging.info("Original RIS Server Bug, restart "
+                                     "scraping paper %s", paper_url)
+            except:
+                pass
+            if not try_found:
+                # check for page errors
+                try:
+                    if 'Fehlermeldung' in page_title:
+                        logging.info("Page %s cannot be accessed due to "
+                                     "server error", paper_url)
+                        return
+                    if 'Berechtigungsfehler' in page_title:
+                        logging.info("Page %s cannot be accessed due to "
+                                     "permissions", paper_url)
+                        return
+                except:
+                    pass
+
+                paper.originalUrl = paper_url
+                superordinated_papers = []
+                subordinated_papers = []
+
+                # Paper title
+                try:
+                    stitle = dom.xpath(self.xpath['PAPER_DETAIL_TITLE'])
+                    paper.title = stitle[0].text
+                except:
+                    logging.critical('Cannot find paper title element using '
+                                     'XPath PAPER_DETAIL_TITLE')
+                    raise TemplateError('Cannot find paper title element '
+                                        'using XPath PAPER_DETAIL_TITLE')
+
+                # Paper identifier, date, type etc
+                tds = dom.xpath(self.xpath['PAPER_DETAIL_IDENTIFIER_TD'])
+                if len(tds) == 0:
+                    logging.critical('Cannot find table fields using XPath '
+                                     'PAPER_DETAIL_IDENTIFIER_TD')
+                    logging.critical('HTML Dump: %s', html)
+                    raise TemplateError('Cannot find table fields using XPath '
+                                        'PAPER_DETAIL_IDENTIFIER_TD')
+                else:
+                    current_category = None
+                    for n in range(0, len(tds)):
+                        try:
+                            tdcontent = tds[n].text.strip()
+                        except:
+                            continue
+                        if tdcontent == 'Name:':
+                            paper.nameShort = tds[n + 1].text.strip()
+                        # TODO: Dereferenzierung von Paper Type Strings
+                        elif tdcontent == 'Art:':
+                            paper.paperType = tds[n + 1].text.strip()
+                        elif tdcontent == 'Datum:':
+                            paper.publishedDate = tds[n + 1].text.strip()
+                        elif tdcontent == 'Betreff:':
+                            paper.name = '; '.join(tds[n + 1].xpath('./text()'))
+                        elif tdcontent == 'Aktenzeichen:':
+                            paper.reference = tds[n + 1].text.strip()
+                        elif tdcontent == 'Referenzvorlage:':
+                            link = tds[n + 1].xpath('a')[0]
+                            href = link.get('href')
+                            parsed = parse.search(
+                                self.urls['PAPER_DETAIL_PARSE_PATTERN'], href)
+                            superordinated_paper = Paper(
+                                originalId=parsed['paper_id'],
+                                nameShort=link.text.strip())
+                            superordinated_papers.append(superordinated_paper)
+                            # add superordinate paper to queue
+                            if hasattr(self, 'paper_queue'):
+                                self.paper_queue.add(parsed['paper_id'])
+                        # subordinate papers are added to the queue
+                        elif tdcontent == 'Untergeordnete Vorlage(n):':
+                            current_category = 'subordinates'
+                            for link in tds[n + 1].xpath('a'):
+                                href = link.get('href')
+                                parsed = parse.search(
+                                    self.urls['PAPER_DETAIL_PARSE_PATTERN'],
+                                    href)
+                                subordinated_paper = Paper(
+                                    originalId=parsed['paper_id'],
+                                    nameShort=link.text.strip())
+                                subordinated_papers.append(subordinated_paper)
+                                if (hasattr(self, 'paper_queue')
+                                        and parsed is not None):
+                                    # add subordinate paper to queue
+                                    self.paper_queue.add(parsed['paper_id'])
+                        elif tdcontent == u'Anträge zur Vorlage:':
+                            current_category = 'todo'
+                        else:
+                            if ((current_category == 'subordinates')
+                                    and (len(tds) > n + 1)):
+                                for link in tds[n + 1].xpath('a'):
+                                    href = link.get('href')
+                                    parsed = parse.search(
+                                        self.urls['PAPER_DETAIL_PARSE_PATTERN'],
+                                        href)
+                                    subordinated_paper = Paper(
+                                        originalId=parsed['paper_id'],
+                                        nameShort=link.text.strip())
+                                    subordinated_papers.append(
+                                        subordinated_paper)
+                                    if (hasattr(self, 'paper_queue')
+                                            and parsed is not None):
+                                        self.paper_queue.add(parsed['paper_id'])
+                    if subordinated_papers:
+                        paper.subordinatedPaper = subordinated_papers
+                    if superordinated_papers:
+                        paper.superordinatedPaper = superordinated_papers
+                    if not hasattr(paper, 'originalId'):
+                        logging.critical('Cannot find paper identifier using '
+                                         'MEETING_DETAIL_IDENTIFIER_TD')
+                        raise TemplateError(
+                            'Cannot find paper identifier using '
+                            'MEETING_DETAIL_IDENTIFIER_TD')
+
+                # "Beratungsfolge"(list of sessions for this paper)
+                # This is currently not parsed for scraping, but only for
+                # gathering session-document ids for later exclusion
+                # Already changed: found_files, files. todo: document_foo
+                found_files = []
+                rows = dom.xpath(self.xpath['PAPER_DETAIL_AGENDA_ROWS'])
+                for row in rows:
+                    # find forms
+                    formfields = row.xpath('.//input[@type="hidden"]'
+                                           '[@name="DT"]')
+                    for formfield in formfields:
+                        file_id = formfield.get('value')
+                        if file_id is not None:
+                            found_files.append(file_id)
+                    # find links
+                    links = row.xpath('.//a[contains(@href,"getfile.")]')
+                    for link in links:
+                        if not link.xpath('.//img'):
+                            file_link = (self.config['scraper']['base_url']
+                                         + link.get('href'))
+                            file_id = file_link.split('id=')[1].split('&')[0]
+                            found_files.append(file_id)
+                # paper-related documents
+                files = []
+                containers = dom.xpath(self.xpath['PAPER_DETAIL_FILES'])
+                for container in containers:
+                    try:
+                        classes = container.get('class').split(' ')
+                    except:
+                        continue
+                    if (self.xpath['PAPER_DETAIL_FILES_CONTAINER_CLASSNAME']
+                            not in classes):
+                        continue
+                    rows = container.xpath('.//tr')
+                    for row in rows:
+                        # seems that we have direct links
+                        if not row.xpath('.//form'):
+                            links = row.xpath('.//a')
+                            for link in links:
+                                # ignore additional pdf icon links
+                                if not link.xpath('.//img'):
+                                    name = ' '.join(link.xpath(
+                                        './text()')).strip()
+                                    file_link = self.config['scraper'][
+                                        'base_url'] + link.get('href')
+                                    file_id = file_link.split('id=')[1].split(
+                                        '&')[0]
+                                    if file_id in found_files:
+                                        continue
+                                    file_obj = File(
+                                        originalId=file_id,
+                                        name=name,
+                                        originalUrl=file_link,
+                                        originalDownloadPossible=True)
+                                    file_obj = self.get_file(file_obj,
+                                                             link=file_link)
+                                    files.append(file_obj)
+                                    found_files.append(file_id)
+
+                        # no direct link, so we have to handle forms
+                        else:
+                            forms = row.xpath('.//form')
+                            for form in forms:
+                                name = " ".join(row.xpath(
+                                    './td/text()')).strip()
+                                for hidden_field in form.xpath(
+                                        'input[@name="DT"]'):
+                                    file_id = hidden_field.get('value')
+                                    if file_id in found_files:
+                                        continue
+                                    file_obj = File(
+                                        originalId=file_id,
+                                        name=name,
+                                        originalDownloadPossible=False)
+                                    # Traversing the whole mechanize response
+                                    # to submit this form.
+                                    for mform in mechanize_forms:
+                                        for control in mform.controls:
+                                            if ((control.name == 'DT') and
+                                                    (control.value == file_id)):
+                                                file_obj = self.get_file(
+                                                    file_obj, form=mform)
+                                                files.append(file_obj)
+                                                found_files.append(file_id)
+                if files:
+                    paper.mainFile = files[0]
+                if len(files) > 1:
+                    paper.auxiliaryFile = files[1:]
+                oid = self.db.save_paper(paper)
+
+    def get_file(self, file_obj, form=None, link=None):
+        """
+        Loads the file from the server and stores it into
+        the file object given as a parameter. The form
+        parameter is the mechanize Form to be submitted for downloading
+        the file.
+
+        The file parameter has to be an object of type
+        model.file.File.
+        """
+        logging.info("Getting file '%s'", file_obj.originalId)
+        if form:
+            mechanize_request = form.click()
+        elif link:
+            mechanize_request = mechanize.Request(link)
         else:
-          logging.critical("HTTP Error %s while getting %s", e.code, link)
-          return
-    return file
-  
-  def make_filename(self, file):
-    ext = 'dat'
-    
-    try:
-      name = file.name
-    except AttributeError:
-      name = file.originalId
-    
-    for extension in self.config['file_extensions']:
-      if extension[0] == file.mimetype:
-        ext = extension[1]
-        break
-    if ext == 'dat':
-      logging.warn("No entry in config:main:file_extensions for %s at file id %s", file.mimetype, file.originalId)
-    # Verhindere Dateinamen > 255 Zeichen
-    name = name[:192]
-    return name + '.' + ext
+            logging.warn("No form or link provided")
 
-  def list_in_string(self, stringlist, string):
-    """
-    Tests if one of the strings in stringlist in contained in string.
-    """
-    for lstring in stringlist:
-      if lstring in string:
-        return True
-    return False
+        retry_counter = 0
+        while retry_counter < 4:
+            retry = False
+            try:
+                mform_response = mechanize.urlopen(mechanize_request)
+                retry_counter = 4
+                mform_url = mform_response.geturl()
+                if not self.list_in_string(self.urls['FILE_DOWNLOAD_TARGET'],
+                                           mform_url) and form:
+                    logging.warn("Unexpected form target URL '%s'", mform_url)
+                    return file_obj
+                file_obj.content = mform_response.read()
+                if ((ord(file_obj.content[0]) == 32)
+                        and (ord(file_obj.content[1]) == 10)):
+                    file_obj.content = file_obj.content[2:]
+                file_obj.mimetype = magic.from_buffer(file_obj.content,
+                                                      mime=True)
+                file_obj.filename = self.make_filename(file_obj)
+            except mechanize.HTTPError as e:
+                if e.code in (500, 502):
+                    retry_counter += 1
+                    retry = True
+                    logging.info("HTTP Error %s while getting %s, try again",
+                                 e.code, link)
+                    time.sleep(self.config['scraper']['wait_time'] * 5)
+                else:
+                    logging.critical("HTTP Error %s while getting %s",
+                                     e.code, link)
+                    return
+        return file_obj
 
-  def get_url(self, url):
-    retry_counter = 0
-    while retry_counter < 4:
-      retry = False
-      try:
-        response = self.user_agent.open(url)
-        return response
-      except urllib2.HTTPError,e:
-        if e.code == 502 or e.code == 500:
-          retry_counter = retry_counter + 1
-          retry = True
-          logging.info("HTTP Error %s while getting %s, try again" % (e.code, url))
-          time.sleep(self.config['scraper']['wait_time'] * 5)
-        else:
-          logging.critical("HTTP Error %s while getting %s", e.code, url)
-          sys.stderr.write("CRITICAL ERROR:HTTP Error %s while getting %s" % (e.code, url))
-    if retry_counter == 4 and retry == True:
-      logging.critical("HTTP Error %s while getting %s", url)
-      sys.stderr.write("CRITICAL ERROR:HTTP Error %s while getting %s" % url)
-      return False
+    def make_filename(self, file_obj):
+        ext = 'dat'
+
+        try:
+            name = file_obj.name
+        except AttributeError:
+            name = file_obj.originalId
+
+        for extension in self.config['file_extensions']:
+            if extension[0] == file_obj.mimetype:
+                ext = extension[1]
+                break
+        if ext == 'dat':
+            logging.warn("No entry in config:main:file_extensions for %s at "
+                         "file id %s", file_obj.mimetype, file_obj.originalId)
+        # Verhindere Dateinamen > 255 Zeichen
+        name = name[:192]
+        return name + '.' + ext
+
+    def list_in_string(self, stringlist, string):
+        """
+        Tests if one of the strings in stringlist in contained in string.
+        """
+        for lstring in stringlist:
+            if lstring in string:
+                return True
+        return False
+
+    def get_url(self, url):
+        retry_counter = 0
+        while retry_counter < 4:
+            retry = False
+            try:
+                response = self.user_agent.open(url)
+                return response
+            except urllib2.HTTPError, e:
+                if e.code in (500, 502):
+                    retry_counter = retry_counter + 1
+                    retry = True
+                    logging.info("HTTP Error %s while getting %s, try again",
+                                 e.code, url)
+                    time.sleep(self.config['scraper']['wait_time'] * 5)
+                else:
+                    logging.critical("HTTP Error %s while getting %s",
+                                     e.code, url)
+                    sys.stderr.write("CRITICAL ERROR:HTTP Error %s while "
+                                     "getting %s" % (e.code, url))
+        if (retry_counter == 4) and retry:
+            logging.critical("HTTP Error while getting %s", url)
+            sys.stderr.write("CRITICAL ERROR:HTTP Error while getting %s"
+                             % url)
+            return False
 
 class TemplateError(Exception):
-  def __init__(self, message):
-    Exception.__init__(self, message)
+    def __init__(self, message):
+        Exception.__init__(self, message)


### PR DESCRIPTION
Behebung verschiedener pylint-Warnungen (vor allem für [PEP8](https://www.python.org/dev/peps/pep-0008)):
- Einrückung
- Zeilenlänge
- type-Vergleich -> isinstanceof
- nicht verwendete Imports
- builtin-Überlagerung (file, format)

Die Zeilenverkürzung wurde besonders in den tiefverschachtelten Funktionen der beiden Scraper etwas hässlich, aber ich mochte meinen Augen zuliebe keine Umtrukturierung angehen, solange der Code unüblich formatiert ist :)
