### PR TITLE
scraper/get_file: korrigiere fehlerhafte Objekt-Referenz

### DIFF
--- a/risscraper/scraperallris.py
+++ b/risscraper/scraperallris.py
@@ -883,7 +883,7 @@ class ScraperAllRis(object):
         file_obj.content = file_file.content
         # catch strange magic exception
         try:
-            file.mimetype = magic.from_buffer(file_obj.content, mime=True)
+            file_obj.mimetype = magic.from_buffer(file_obj.content, mime=True)
         except magic.MagicException:
             logging.warn("Warning: unknown magic error at file %s from %s",
                          file_obj.originalId, file_url)


### PR DESCRIPTION
Nachkorrektur von a882e0ef4a06f407548e6f99f8bd02582b236431
